### PR TITLE
fix(core,ffi): wasmer memory limits to run on real iOS device

### DIFF
--- a/mopro-core/Cargo.toml
+++ b/mopro-core/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[patch.crates-io]
+# NOTE: Forked wasmer to work around memory limits
+# See https://github.com/wasmerio/wasmer/commit/09c7070
+wasmer = { git = "https://github.com/oskarth/wasmer.git", rev = "09c7070" }
+
 [dependencies]
 ark-circom = { git = "https://github.com/arkworks-rs/circom-compat.git" }
 serde = { version = "1.0", features = ["derive"] }

--- a/mopro-ffi/Cargo.toml
+++ b/mopro-ffi/Cargo.toml
@@ -13,6 +13,11 @@ name = "mopro_ffi"
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
+[patch.crates-io]
+# NOTE: Forked wasmer to work around memory limits
+# See https://github.com/wasmerio/wasmer/commit/09c7070
+wasmer = { git = "https://github.com/oskarth/wasmer.git", rev = "09c7070" }
+
 [dependencies]
 mopro-core = { path = "../mopro-core" }
 uniffi = { version = "0.24", features = ["cli"] }


### PR DESCRIPTION
Fixes https://github.com/oskarth/mopro/issues/1

This commit uses a forked version of wasmer to workaround memory limits when running ark-circom WitnessCalculator on a real iOS device.

See https://github.com/wasmerio/wasmer/commit/09c7070 for details. Thanks to philsippl for helping identify this fix.

Note that patch.crates-io ensures we are using our forked version of wasmer for all dependencies. Since we might build from mopro-core or mopro-ffi we need to change both repositories. We can confirm if the forked version is used everywhere with `cargo tree | grep wasmer`.

With this patch, we change the minimum pages from 65536 to 2000, which seems to do the trick:

```
wasmer/memory.rs: Using memory hack to work around memory limits
wasmer/memory.rs: Old minimum pages: 65536 pages
wasmer/memory.rs: Old offset guard bytes: 2147483648
wasmer/memory.rs: New minimum pages: 2000 pages
wasmer/memory.rs: New offset guard bytes: 65536
````