### PR TITLE
fix(core, ffi): should accept bigint inputs

### DIFF
--- a/mopro-ffi/src/mopro.udl
+++ b/mopro-ffi/src/mopro.udl
@@ -27,7 +27,7 @@ interface MoproCircom {
   SetupResult setup(string wasm_path, string r1cs_path);
 
   [Throws=MoproError]
-  GenerateProofResult generate_proof(record<string, sequence<i32>> circuit_inputs);
+  GenerateProofResult generate_proof(record<string, sequence<string>> circuit_inputs);
 
   [Throws=MoproError]
   boolean verify_proof(bytes proof, bytes public_input);

--- a/mopro-ffi/tests/bindings/test_mopro.swift
+++ b/mopro-ffi/tests/bindings/test_mopro.swift
@@ -6,17 +6,17 @@ let moproCircom = MoproCircom()
 let wasmPath = "./../../../../mopro-core/examples/circom/multiplier2/target/multiplier2_js/multiplier2.wasm"
 let r1csPath = "./../../../../mopro-core/examples/circom/multiplier2/target/multiplier2.r1cs"
 
-// TODO: should handle 254-bit input
-func serializeOutputs(_ int32Array: [Int32]) -> [UInt8] {
+func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
     var bytesArray: [UInt8] = []
-    let length = int32Array.count
+    let length = stringArray.count
     var littleEndianLength = length.littleEndian
     let targetLength = 32
     withUnsafeBytes(of: &littleEndianLength) {
         bytesArray.append(contentsOf: $0)
     }
-    for value in int32Array {
-        var littleEndian = value.littleEndian
+    for value in stringArray {
+        // TODO: should handle 254-bit input
+        var littleEndian = Int32(value)!.littleEndian
         var byteLength = 0
         withUnsafeBytes(of: &littleEndian) {
             bytesArray.append(contentsOf: $0)
@@ -37,12 +37,15 @@ do {
     assert(!setupResult.provingKey.isEmpty, "Proving key should not be empty")
 
     // Prepare inputs
-    var inputs = [String: [Int32]]()
-    inputs["a"] = [3]
-    inputs["b"] = [5]
+    var inputs = [String: [String]]()
+    let a = 3
+    let b = 5
+    let c = a*b
+    inputs["a"] = [String(a)]
+    inputs["b"] = [String(b)]
 
     // Expected outputs
-    let outputs: [Int32] = [15, 3]
+    let outputs: [String] = [String(c), String(a)]
     let expectedOutput: [UInt8] = serializeOutputs(outputs)
 
     // Generate Proof

--- a/mopro-ffi/tests/bindings/test_mopro_keccak.swift
+++ b/mopro-ffi/tests/bindings/test_mopro_keccak.swift
@@ -7,28 +7,28 @@ let wasmPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak
 let r1csPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test.r1cs"
 
 // Helper function to convert bytes to bits
-func bytesToBits(bytes: [UInt8]) -> [Int32] {
-    var bits = [Int32]()
+func bytesToBits(bytes: [UInt8]) -> [String] {
+    var bits = [String]()
     for byte in bytes {
         for j in 0..<8 {
             let bit = (byte >> j) & 1
-            bits.append(Int32(bit))
+            bits.append(String(bit))
         }
     }
     return bits
 }
 
-// TODO: should handle 254-bit input
-func serializeOutputs(_ int32Array: [Int32]) -> [UInt8] {
+func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
     var bytesArray: [UInt8] = []
-    let length = int32Array.count
+    let length = stringArray.count
     var littleEndianLength = length.littleEndian
     let targetLength = 32
     withUnsafeBytes(of: &littleEndianLength) {
         bytesArray.append(contentsOf: $0)
     }
-    for value in int32Array {
-        var littleEndian = value.littleEndian
+    for value in stringArray {
+        // TODO: should handle 254-bit input
+        var littleEndian = Int32(value)!.littleEndian
         var byteLength = 0
         withUnsafeBytes(of: &littleEndian) {
             bytesArray.append(contentsOf: $0)
@@ -54,7 +54,7 @@ do {
         0, 0, 0, 0, 0, 0,
     ]
     let bits = bytesToBits(bytes: inputVec)
-    var inputs = [String: [Int32]]()
+    var inputs = [String: [String]]()
     inputs["in"] = bits
 
     // Expected outputs
@@ -62,7 +62,7 @@ do {
         37, 17, 98, 135, 161, 178, 88, 97, 125, 150, 143, 65, 228, 211, 170, 133, 153, 9, 88,
         212, 4, 212, 175, 238, 249, 210, 214, 116, 170, 85, 45, 21,
     ]
-    let outputBits: [Int32] = bytesToBits(bytes: outputVec)
+    let outputBits: [String] = bytesToBits(bytes: outputVec)
     let expectedOutput: [UInt8] = serializeOutputs(outputBits)
 
     // Generate Proof

--- a/mopro-ios/MoproKit/Example/MoproKit/ViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/ViewController.swift
@@ -91,7 +91,7 @@ class ViewController: UIViewController {
                 0, 0, 0, 0, 0, 0,
             ]
             let bits = bytesToBits(bytes: inputVec)
-            var inputs = [String: [Int32]]()
+            var inputs = [String: [String]]()
             inputs["in"] = bits
 
             // Expected outputs
@@ -99,14 +99,17 @@ class ViewController: UIViewController {
                 37, 17, 98, 135, 161, 178, 88, 97, 125, 150, 143, 65, 228, 211, 170, 133, 153, 9, 88,
                 212, 4, 212, 175, 238, 249, 210, 214, 116, 170, 85, 45, 21,
             ]
-            let outputBits: [Int32] = bytesToBits(bytes: outputVec)
+            let outputBits: [String] = bytesToBits(bytes: outputVec)
             let expectedOutput: [UInt8] = serializeOutputs(outputBits)
 
             // Multiplier example
-            // var inputs = [String: [Int32]]()
-            // inputs["a"] = [3]
-            // inputs["b"] = [5]
-            // let outputs: [Int32] = [15, 3]
+            // var inputs = [String: [String]]()
+            // let a = 3
+            // let b = 5
+            // let c = a*b
+            // inputs["a"] = [String(a)]
+            // inputs["b"] = [String(b)]
+            // let outputs: [String] = [String(c), String(a)]
             // let expectedOutput: [UInt8] = serializeOutputs(outputs)
 
             // Record start time
@@ -161,28 +164,28 @@ class ViewController: UIViewController {
 
 }
 
-func bytesToBits(bytes: [UInt8]) -> [Int32] {
-    var bits = [Int32]()
+func bytesToBits(bytes: [UInt8]) -> [String] {
+    var bits = [String]()
     for byte in bytes {
         for j in 0..<8 {
             let bit = (byte >> j) & 1
-            bits.append(Int32(bit))
+            bits.append(String(bit))
         }
     }
     return bits
 }
 
-// TODO: should handle 254-bit input
-func serializeOutputs(_ int32Array: [Int32]) -> [UInt8] {
+func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
     var bytesArray: [UInt8] = []
-    let length = int32Array.count
+    let length = stringArray.count
     var littleEndianLength = length.littleEndian
     let targetLength = 32
     withUnsafeBytes(of: &littleEndianLength) {
         bytesArray.append(contentsOf: $0)
     }
-    for value in int32Array {
-        var littleEndian = value.littleEndian
+    for value in stringArray {
+        // TODO: should handle 254-bit input
+        var littleEndian = Int32(value)!.littleEndian
         var byteLength = 0
         withUnsafeBytes(of: &littleEndian) {
             bytesArray.append(contentsOf: $0)


### PR DESCRIPTION
- **Serialization:** `Fr` -> `BigUInt` -> `String`
- **Deserialization:** `String` -> `BigUInt` -> `Fr`
- Add tests for scalar field input: `21888242871839275222246405745257275088548364400416034343698204186575808495616`