### PR TITLE
Convert proof, inputs for smart contract

### DIFF
--- a/mopro-core/src/middleware/circom/serialization.rs
+++ b/mopro-core/src/middleware/circom/serialization.rs
@@ -1,4 +1,5 @@
 use ark_bn254::Bn254;
+use ark_circom::ethereum;
 use ark_ec::pairing::Pairing;
 use ark_groth16::{Proof, ProvingKey};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -47,6 +48,14 @@ pub fn serialize_inputs(inputs: &SerializableInputs) -> Vec<u8> {
 
 pub fn deserialize_inputs(data: Vec<u8>) -> SerializableInputs {
     SerializableInputs::deserialize_uncompressed(&mut &data[..]).expect("Deserialization failed")
+}
+
+pub fn convert_proof(proof: &SerializableProof) -> ethereum::Proof {
+    ethereum::Proof::from(proof.0.clone())
+}
+
+pub fn convert_inputs(inputs: &SerializableInputs) -> ethereum::Inputs {
+    ethereum::Inputs::from(&inputs.0[..])
 }
 
 #[cfg(test)]

--- a/mopro-core/src/middleware/circom/serialization.rs
+++ b/mopro-core/src/middleware/circom/serialization.rs
@@ -50,11 +50,12 @@ pub fn deserialize_inputs(data: Vec<u8>) -> SerializableInputs {
     SerializableInputs::deserialize_uncompressed(&mut &data[..]).expect("Deserialization failed")
 }
 
-pub fn convert_proof(proof: &SerializableProof) -> ethereum::Proof {
+// Convert proof to U256-tuples as expected by the Solidity Groth16 Verifier
+pub fn to_ethereum_proof(proof: &SerializableProof) -> ethereum::Proof {
     ethereum::Proof::from(proof.0.clone())
 }
 
-pub fn convert_inputs(inputs: &SerializableInputs) -> ethereum::Inputs {
+pub fn to_ethereum_inputs(inputs: &SerializableInputs) -> ethereum::Inputs {
     ethereum::Inputs::from(&inputs.0[..])
 }
 

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -136,9 +136,10 @@ pub fn verify_proof2(proof: Vec<u8>, public_input: Vec<u8>) -> Result<bool, Mopr
     Ok(is_valid)
 }
 
-pub fn convert_proof(proof: Vec<u8>) -> ProofCalldata {
+// Convert proof to String-tuples as expected by the Solidity Groth16 Verifier
+pub fn to_ethereum_proof(proof: Vec<u8>) -> ProofCalldata {
     let deserialized_proof = circom::serialization::deserialize_proof(proof);
-    let proof = circom::serialization::convert_proof(&deserialized_proof);
+    let proof = circom::serialization::to_ethereum_proof(&deserialized_proof);
     let a = G1 {
         x: proof.a.x.to_string(),
         y: proof.a.y.to_string(),
@@ -154,7 +155,7 @@ pub fn convert_proof(proof: Vec<u8>) -> ProofCalldata {
     ProofCalldata { a, b, c }
 }
 
-pub fn convert_inputs(inputs: Vec<u8>) -> Vec<String> {
+pub fn to_ethereum_inputs(inputs: Vec<u8>) -> Vec<String> {
     let deserialized_inputs = circom::serialization::deserialize_inputs(inputs);
     let inputs = deserialized_inputs
         .0
@@ -319,8 +320,8 @@ mod tests {
         assert!(is_valid);
 
         // Step 4: Convert Proof
-        let proof_calldata = convert_proof(serialized_proof);
-        let inputs_calldata = convert_inputs(serialized_inputs);
+        let proof_calldata = to_ethereum_proof(serialized_proof);
+        let inputs_calldata = to_ethereum_inputs(serialized_inputs);
         assert!(proof_calldata.a.x.len() > 0);
         assert!(inputs_calldata.len() > 0);
 
@@ -371,8 +372,8 @@ mod tests {
         assert!(is_valid);
 
         // Step 4: Convert Proof
-        let proof_calldata = convert_proof(serialized_proof);
-        let inputs_calldata = convert_inputs(serialized_inputs);
+        let proof_calldata = to_ethereum_proof(serialized_proof);
+        let inputs_calldata = to_ethereum_inputs(serialized_inputs);
         assert!(proof_calldata.a.x.len() > 0);
         assert!(inputs_calldata.len() > 0);
 

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -319,7 +319,7 @@ mod tests {
             mopro_circom.verify_proof(serialized_proof.clone(), serialized_inputs.clone())?;
         assert!(is_valid);
 
-        // Step 4: Convert Proof
+        // Step 4: Convert Proof to Ethereum compatible proof
         let proof_calldata = to_ethereum_proof(serialized_proof);
         let inputs_calldata = to_ethereum_inputs(serialized_inputs);
         assert!(proof_calldata.a.x.len() > 0);
@@ -371,7 +371,7 @@ mod tests {
             mopro_circom.verify_proof(serialized_proof.clone(), serialized_inputs.clone())?;
         assert!(is_valid);
 
-        // Step 4: Convert Proof
+        // Step 4: Convert Proof to Ethereum compatible proof
         let proof_calldata = to_ethereum_proof(serialized_proof);
         let inputs_calldata = to_ethereum_inputs(serialized_inputs);
         assert!(proof_calldata.a.x.len() > 0);

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -141,7 +141,7 @@ pub fn convert_proof(proof: Vec<u8>) -> ProofCalldata {
     let proof = circom::serialization::convert_proof(&deserialized_proof);
     let a = G1 {
         x: proof.a.x.to_string(),
-        y: proof.a.y.to_string()
+        y: proof.a.y.to_string(),
     };
     let b = G2 {
         x: proof.b.x.iter().map(|x| x.to_string()).collect(),
@@ -149,14 +149,18 @@ pub fn convert_proof(proof: Vec<u8>) -> ProofCalldata {
     };
     let c = G1 {
         x: proof.c.x.to_string(),
-        y: proof.c.y.to_string()
+        y: proof.c.y.to_string(),
     };
     ProofCalldata { a, b, c }
 }
 
 pub fn convert_inputs(inputs: Vec<u8>) -> Vec<String> {
     let deserialized_inputs = circom::serialization::deserialize_inputs(inputs);
-    let inputs = deserialized_inputs.0.iter().map(|x| x.to_string()).collect();
+    let inputs = deserialized_inputs
+        .0
+        .iter()
+        .map(|x| x.to_string())
+        .collect();
     inputs
 }
 
@@ -310,7 +314,8 @@ mod tests {
         assert_eq!(serialized_inputs, serialized_outputs);
 
         // Step 3: Verify Proof
-        let is_valid = mopro_circom.verify_proof(serialized_proof.clone(), serialized_inputs.clone())?;
+        let is_valid =
+            mopro_circom.verify_proof(serialized_proof.clone(), serialized_inputs.clone())?;
         assert!(is_valid);
 
         // Step 4: Convert Proof
@@ -361,7 +366,8 @@ mod tests {
 
         // Step 3: Verify Proof
 
-        let is_valid = mopro_circom.verify_proof(serialized_proof.clone(), serialized_inputs.clone())?;
+        let is_valid =
+            mopro_circom.verify_proof(serialized_proof.clone(), serialized_inputs.clone())?;
         assert!(is_valid);
 
         // Step 4: Convert Proof

--- a/mopro-ffi/src/lib.rs
+++ b/mopro-ffi/src/lib.rs
@@ -22,6 +22,25 @@ pub struct GenerateProofResult {
     pub inputs: Vec<u8>,
 }
 
+#[derive(Debug, Clone)]
+pub struct G1 {
+    pub x: String,
+    pub y: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct G2 {
+    pub x: Vec<String>,
+    pub y: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProofCalldata {
+    pub a: G1,
+    pub b: G2,
+    pub c: G1,
+}
+
 // NOTE: Make UniFFI and Rust happy, can maybe do some renaming here
 #[allow(non_snake_case)]
 #[derive(Debug, Clone)]
@@ -115,6 +134,30 @@ pub fn verify_proof2(proof: Vec<u8>, public_input: Vec<u8>) -> Result<bool, Mopr
     let deserialized_public_input = circom::serialization::deserialize_inputs(public_input);
     let is_valid = circom::verify_proof2(deserialized_proof, deserialized_public_input)?;
     Ok(is_valid)
+}
+
+pub fn convert_proof(proof: Vec<u8>) -> ProofCalldata {
+    let deserialized_proof = circom::serialization::deserialize_proof(proof);
+    let proof = circom::serialization::convert_proof(&deserialized_proof);
+    let a = G1 {
+        x: proof.a.x.to_string(),
+        y: proof.a.y.to_string()
+    };
+    let b = G2 {
+        x: proof.b.x.iter().map(|x| x.to_string()).collect(),
+        y: proof.b.y.iter().map(|x| x.to_string()).collect(),
+    };
+    let c = G1 {
+        x: proof.c.x.to_string(),
+        y: proof.c.y.to_string()
+    };
+    ProofCalldata { a, b, c }
+}
+
+pub fn convert_inputs(inputs: Vec<u8>) -> Vec<String> {
+    let deserialized_inputs = circom::serialization::deserialize_inputs(inputs);
+    let inputs = deserialized_inputs.0.iter().map(|x| x.to_string()).collect();
+    inputs
 }
 
 // TODO: Use FFIError::SerializationError instead
@@ -267,8 +310,14 @@ mod tests {
         assert_eq!(serialized_inputs, serialized_outputs);
 
         // Step 3: Verify Proof
-        let is_valid = mopro_circom.verify_proof(serialized_proof, serialized_inputs)?;
+        let is_valid = mopro_circom.verify_proof(serialized_proof.clone(), serialized_inputs.clone())?;
         assert!(is_valid);
+
+        // Step 4: Convert Proof
+        let proof_calldata = convert_proof(serialized_proof);
+        let inputs_calldata = convert_inputs(serialized_inputs);
+        assert!(proof_calldata.a.x.len() > 0);
+        assert!(inputs_calldata.len() > 0);
 
         Ok(())
     }
@@ -312,8 +361,14 @@ mod tests {
 
         // Step 3: Verify Proof
 
-        let is_valid = mopro_circom.verify_proof(serialized_proof, serialized_inputs)?;
+        let is_valid = mopro_circom.verify_proof(serialized_proof.clone(), serialized_inputs.clone())?;
         assert!(is_valid);
+
+        // Step 4: Convert Proof
+        let proof_calldata = convert_proof(serialized_proof);
+        let inputs_calldata = convert_inputs(serialized_inputs);
+        assert!(proof_calldata.a.x.len() > 0);
+        assert!(inputs_calldata.len() > 0);
 
         Ok(())
     }

--- a/mopro-ffi/src/mopro.udl
+++ b/mopro-ffi/src/mopro.udl
@@ -16,6 +16,9 @@ namespace mopro {
 
   [Throws=MoproError]
   BenchmarkResult run_msm_benchmark(u32? num_msm);
+  
+  ProofCalldata convert_proof(bytes proof);
+  sequence<string> convert_inputs(bytes inputs);
 };
 
 dictionary SetupResult {
@@ -33,6 +36,23 @@ dictionary BenchmarkResult {
   double total_processing_time;
   u32 allocated_memory;
 };
+
+dictionary G1 {
+  string x;
+  string y;
+};
+
+dictionary G2 {
+  sequence<string> x;
+  sequence<string> y;
+};
+
+dictionary ProofCalldata {
+  G1 a;
+  G2 b;
+  G1 c;
+};
+
 
 [Error]
 enum MoproError {

--- a/mopro-ffi/src/mopro.udl
+++ b/mopro-ffi/src/mopro.udl
@@ -17,8 +17,8 @@ namespace mopro {
   [Throws=MoproError]
   BenchmarkResult run_msm_benchmark(u32? num_msm);
   
-  ProofCalldata convert_proof(bytes proof);
-  sequence<string> convert_inputs(bytes inputs);
+  ProofCalldata to_ethereum_proof(bytes proof);
+  sequence<string> to_ethereum_inputs(bytes inputs);
 };
 
 dictionary SetupResult {

--- a/mopro-ffi/tests/bindings/test_mopro.kts
+++ b/mopro-ffi/tests/bindings/test_mopro.kts
@@ -4,18 +4,31 @@ var wasmPath = "../mopro-core/examples/circom/multiplier2/target/multiplier2_js/
 var r1csPath = "../mopro-core/examples/circom/multiplier2/target/multiplier2.r1cs"
 
 try {
+    // Setup
     var moproCircom = MoproCircom()
     var setupResult = moproCircom.setup(wasmPath, r1csPath)
     assert(setupResult.provingKey.size > 0) { "Proving key should not be empty" }
 
+    // Prepare inputs
     val inputs = mutableMapOf<String, List<String>>()
     inputs["a"] = listOf("3")
     inputs["b"] = listOf("5")
 
+    // Generate proof
     var generateProofResult = moproCircom.generateProof(inputs)
     assert(generateProofResult.proof.size > 0) { "Proof is empty" }
+
+    // Verify proof
     var isValid = moproCircom.verifyProof(generateProofResult.proof, generateProofResult.inputs)
     assert(isValid) { "Proof is invalid" }
+
+    // Convert proof
+    var convertProofResult = convertProof(generateProofResult.proof)
+    var convertInputsResult = convertInputs(generateProofResult.inputs)
+    assert(convertProofResult.a.x.isNotEmpty()) { "Proof is empty" }
+    assert(convertInputsResult.size > 0) { "Inputs are empty" }
+
+
 } catch (e: Exception) {
     println(e)
 }

--- a/mopro-ffi/tests/bindings/test_mopro.kts
+++ b/mopro-ffi/tests/bindings/test_mopro.kts
@@ -22,9 +22,9 @@ try {
     var isValid = moproCircom.verifyProof(generateProofResult.proof, generateProofResult.inputs)
     assert(isValid) { "Proof is invalid" }
 
-    // Convert proof
-    var convertProofResult = convertProof(generateProofResult.proof)
-    var convertInputsResult = convertInputs(generateProofResult.inputs)
+    // Convert proof to Ethereum compatible proof
+    var convertProofResult = toEthereumProof(generateProofResult.proof)
+    var convertInputsResult = toEthereumInputs(generateProofResult.inputs)
     assert(convertProofResult.a.x.isNotEmpty()) { "Proof is empty" }
     assert(convertInputsResult.size > 0) { "Inputs are empty" }
 

--- a/mopro-ffi/tests/bindings/test_mopro.swift
+++ b/mopro-ffi/tests/bindings/test_mopro.swift
@@ -58,9 +58,9 @@ do {
     let isValid = try moproCircom.verifyProof(proof: generateProofResult.proof, publicInput: generateProofResult.inputs)
     assert(isValid, "Proof verification should succeed")
 
-    // Convert Proof
-    let convertProofResult = convertProof(proof: generateProofResult.proof)
-    let convertInputsResult = convertInputs(inputs: generateProofResult.inputs)
+    // Convert proof to Ethereum compatible proof
+    let convertProofResult = toEthereumProof(proof: generateProofResult.proof)
+    let convertInputsResult = toEthereumInputs(inputs: generateProofResult.inputs)
     assert(convertProofResult.a.x.count > 0, "Proof should not be empty")
     assert(convertInputsResult.count > 0, "Inputs should not be empty")
 

--- a/mopro-ffi/tests/bindings/test_mopro.swift
+++ b/mopro-ffi/tests/bindings/test_mopro.swift
@@ -58,6 +58,12 @@ do {
     let isValid = try moproCircom.verifyProof(proof: generateProofResult.proof, publicInput: generateProofResult.inputs)
     assert(isValid, "Proof verification should succeed")
 
+    // Convert Proof
+    let convertProofResult = convertProof(proof: generateProofResult.proof)
+    let convertInputsResult = convertInputs(inputs: generateProofResult.inputs)
+    assert(convertProofResult.a.x.count > 0, "Proof should not be empty")
+    assert(convertInputsResult.count > 0, "Inputs should not be empty")
+
 } catch let error as MoproError {
     print("MoproError: \(error)")
 } catch {

--- a/mopro-ios/MoproKit/Bindings/mopro.swift
+++ b/mopro-ios/MoproKit/Bindings/mopro.swift
@@ -310,6 +310,19 @@ fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
     }
 }
 
+fileprivate struct FfiConverterDouble: FfiConverterPrimitive {
+    typealias FfiType = Double
+    typealias SwiftType = Double
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Double {
+        return try lift(readDouble(&buf))
+    }
+
+    public static func write(_ value: Double, into buf: inout [UInt8]) {
+        writeDouble(&buf, lower(value))
+    }
+}
+
 fileprivate struct FfiConverterBool : FfiConverter {
     typealias FfiType = Int8
     typealias SwiftType = Bool
@@ -492,6 +505,187 @@ public func FfiConverterTypeMoproCircom_lower(_ value: MoproCircom) -> UnsafeMut
 }
 
 
+public struct BenchmarkResult {
+    public var numMsm: UInt32
+    public var avgProcessingTime: Double
+    public var totalProcessingTime: Double
+    public var allocatedMemory: UInt32
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(numMsm: UInt32, avgProcessingTime: Double, totalProcessingTime: Double, allocatedMemory: UInt32) {
+        self.numMsm = numMsm
+        self.avgProcessingTime = avgProcessingTime
+        self.totalProcessingTime = totalProcessingTime
+        self.allocatedMemory = allocatedMemory
+    }
+}
+
+
+extension BenchmarkResult: Equatable, Hashable {
+    public static func ==(lhs: BenchmarkResult, rhs: BenchmarkResult) -> Bool {
+        if lhs.numMsm != rhs.numMsm {
+            return false
+        }
+        if lhs.avgProcessingTime != rhs.avgProcessingTime {
+            return false
+        }
+        if lhs.totalProcessingTime != rhs.totalProcessingTime {
+            return false
+        }
+        if lhs.allocatedMemory != rhs.allocatedMemory {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(numMsm)
+        hasher.combine(avgProcessingTime)
+        hasher.combine(totalProcessingTime)
+        hasher.combine(allocatedMemory)
+    }
+}
+
+
+public struct FfiConverterTypeBenchmarkResult: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BenchmarkResult {
+        return try BenchmarkResult(
+            numMsm: FfiConverterUInt32.read(from: &buf), 
+            avgProcessingTime: FfiConverterDouble.read(from: &buf), 
+            totalProcessingTime: FfiConverterDouble.read(from: &buf), 
+            allocatedMemory: FfiConverterUInt32.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: BenchmarkResult, into buf: inout [UInt8]) {
+        FfiConverterUInt32.write(value.numMsm, into: &buf)
+        FfiConverterDouble.write(value.avgProcessingTime, into: &buf)
+        FfiConverterDouble.write(value.totalProcessingTime, into: &buf)
+        FfiConverterUInt32.write(value.allocatedMemory, into: &buf)
+    }
+}
+
+
+public func FfiConverterTypeBenchmarkResult_lift(_ buf: RustBuffer) throws -> BenchmarkResult {
+    return try FfiConverterTypeBenchmarkResult.lift(buf)
+}
+
+public func FfiConverterTypeBenchmarkResult_lower(_ value: BenchmarkResult) -> RustBuffer {
+    return FfiConverterTypeBenchmarkResult.lower(value)
+}
+
+
+public struct G1 {
+    public var x: String
+    public var y: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(x: String, y: String) {
+        self.x = x
+        self.y = y
+    }
+}
+
+
+extension G1: Equatable, Hashable {
+    public static func ==(lhs: G1, rhs: G1) -> Bool {
+        if lhs.x != rhs.x {
+            return false
+        }
+        if lhs.y != rhs.y {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(x)
+        hasher.combine(y)
+    }
+}
+
+
+public struct FfiConverterTypeG1: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> G1 {
+        return try G1(
+            x: FfiConverterString.read(from: &buf), 
+            y: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: G1, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.x, into: &buf)
+        FfiConverterString.write(value.y, into: &buf)
+    }
+}
+
+
+public func FfiConverterTypeG1_lift(_ buf: RustBuffer) throws -> G1 {
+    return try FfiConverterTypeG1.lift(buf)
+}
+
+public func FfiConverterTypeG1_lower(_ value: G1) -> RustBuffer {
+    return FfiConverterTypeG1.lower(value)
+}
+
+
+public struct G2 {
+    public var x: [String]
+    public var y: [String]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(x: [String], y: [String]) {
+        self.x = x
+        self.y = y
+    }
+}
+
+
+extension G2: Equatable, Hashable {
+    public static func ==(lhs: G2, rhs: G2) -> Bool {
+        if lhs.x != rhs.x {
+            return false
+        }
+        if lhs.y != rhs.y {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(x)
+        hasher.combine(y)
+    }
+}
+
+
+public struct FfiConverterTypeG2: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> G2 {
+        return try G2(
+            x: FfiConverterSequenceString.read(from: &buf), 
+            y: FfiConverterSequenceString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: G2, into buf: inout [UInt8]) {
+        FfiConverterSequenceString.write(value.x, into: &buf)
+        FfiConverterSequenceString.write(value.y, into: &buf)
+    }
+}
+
+
+public func FfiConverterTypeG2_lift(_ buf: RustBuffer) throws -> G2 {
+    return try FfiConverterTypeG2.lift(buf)
+}
+
+public func FfiConverterTypeG2_lower(_ value: G2) -> RustBuffer {
+    return FfiConverterTypeG2.lower(value)
+}
+
+
 public struct GenerateProofResult {
     public var proof: Data
     public var inputs: Data
@@ -544,6 +738,69 @@ public func FfiConverterTypeGenerateProofResult_lift(_ buf: RustBuffer) throws -
 
 public func FfiConverterTypeGenerateProofResult_lower(_ value: GenerateProofResult) -> RustBuffer {
     return FfiConverterTypeGenerateProofResult.lower(value)
+}
+
+
+public struct ProofCalldata {
+    public var a: G1
+    public var b: G2
+    public var c: G1
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(a: G1, b: G2, c: G1) {
+        self.a = a
+        self.b = b
+        self.c = c
+    }
+}
+
+
+extension ProofCalldata: Equatable, Hashable {
+    public static func ==(lhs: ProofCalldata, rhs: ProofCalldata) -> Bool {
+        if lhs.a != rhs.a {
+            return false
+        }
+        if lhs.b != rhs.b {
+            return false
+        }
+        if lhs.c != rhs.c {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(a)
+        hasher.combine(b)
+        hasher.combine(c)
+    }
+}
+
+
+public struct FfiConverterTypeProofCalldata: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ProofCalldata {
+        return try ProofCalldata(
+            a: FfiConverterTypeG1.read(from: &buf), 
+            b: FfiConverterTypeG2.read(from: &buf), 
+            c: FfiConverterTypeG1.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: ProofCalldata, into buf: inout [UInt8]) {
+        FfiConverterTypeG1.write(value.a, into: &buf)
+        FfiConverterTypeG2.write(value.b, into: &buf)
+        FfiConverterTypeG1.write(value.c, into: &buf)
+    }
+}
+
+
+public func FfiConverterTypeProofCalldata_lift(_ buf: RustBuffer) throws -> ProofCalldata {
+    return try FfiConverterTypeProofCalldata.lift(buf)
+}
+
+public func FfiConverterTypeProofCalldata_lower(_ value: ProofCalldata) -> RustBuffer {
+    return FfiConverterTypeProofCalldata.lower(value)
 }
 
 
@@ -645,6 +902,27 @@ extension MoproError: Equatable, Hashable {}
 
 extension MoproError: Error { }
 
+fileprivate struct FfiConverterOptionUInt32: FfiConverterRustBuffer {
+    typealias SwiftType = UInt32?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterUInt32.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterUInt32.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
 fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
     typealias SwiftType = [String]
 
@@ -700,6 +978,24 @@ public func add(a: UInt32, b: UInt32)  -> UInt32 {
     )
 }
 
+public func convertInputs(inputs: Data)  -> [String] {
+    return try!  FfiConverterSequenceString.lift(
+        try! rustCall() {
+    uniffi_mopro_ffi_fn_func_convert_inputs(
+        FfiConverterData.lower(inputs),$0)
+}
+    )
+}
+
+public func convertProof(proof: Data)  -> ProofCalldata {
+    return try!  FfiConverterTypeProofCalldata.lift(
+        try! rustCall() {
+    uniffi_mopro_ffi_fn_func_convert_proof(
+        FfiConverterData.lower(proof),$0)
+}
+    )
+}
+
 public func generateProof2(circuitInputs: [String: [String]]) throws -> GenerateProofResult {
     return try  FfiConverterTypeGenerateProofResult.lift(
         try rustCallWithError(FfiConverterTypeMoproError.lift) {
@@ -734,6 +1030,15 @@ public func initializeMoproDylib(dylibPath: String) throws {
 
 
 
+public func runMsmBenchmark(numMsm: UInt32?) throws -> BenchmarkResult {
+    return try  FfiConverterTypeBenchmarkResult.lift(
+        try rustCallWithError(FfiConverterTypeMoproError.lift) {
+    uniffi_mopro_ffi_fn_func_run_msm_benchmark(
+        FfiConverterOptionUInt32.lower(numMsm),$0)
+}
+    )
+}
+
 public func verifyProof2(proof: Data, publicInput: Data) throws -> Bool {
     return try  FfiConverterBool.lift(
         try rustCallWithError(FfiConverterTypeMoproError.lift) {
@@ -762,6 +1067,12 @@ private var initializationResult: InitializationResult {
     if (uniffi_mopro_ffi_checksum_func_add() != 8411) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mopro_ffi_checksum_func_convert_inputs() != 59191) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mopro_ffi_checksum_func_convert_proof() != 6119) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mopro_ffi_checksum_func_generate_proof2() != 40187) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -772,6 +1083,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mopro_ffi_checksum_func_initialize_mopro_dylib() != 64476) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mopro_ffi_checksum_func_run_msm_benchmark() != 7930) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mopro_ffi_checksum_func_verify_proof2() != 37192) {

--- a/mopro-ios/MoproKit/Bindings/mopro.swift
+++ b/mopro-ios/MoproKit/Bindings/mopro.swift
@@ -978,24 +978,6 @@ public func add(a: UInt32, b: UInt32)  -> UInt32 {
     )
 }
 
-public func convertInputs(inputs: Data)  -> [String] {
-    return try!  FfiConverterSequenceString.lift(
-        try! rustCall() {
-    uniffi_mopro_ffi_fn_func_convert_inputs(
-        FfiConverterData.lower(inputs),$0)
-}
-    )
-}
-
-public func convertProof(proof: Data)  -> ProofCalldata {
-    return try!  FfiConverterTypeProofCalldata.lift(
-        try! rustCall() {
-    uniffi_mopro_ffi_fn_func_convert_proof(
-        FfiConverterData.lower(proof),$0)
-}
-    )
-}
-
 public func generateProof2(circuitInputs: [String: [String]]) throws -> GenerateProofResult {
     return try  FfiConverterTypeGenerateProofResult.lift(
         try rustCallWithError(FfiConverterTypeMoproError.lift) {
@@ -1039,6 +1021,24 @@ public func runMsmBenchmark(numMsm: UInt32?) throws -> BenchmarkResult {
     )
 }
 
+public func toEthereumInputs(inputs: Data)  -> [String] {
+    return try!  FfiConverterSequenceString.lift(
+        try! rustCall() {
+    uniffi_mopro_ffi_fn_func_to_ethereum_inputs(
+        FfiConverterData.lower(inputs),$0)
+}
+    )
+}
+
+public func toEthereumProof(proof: Data)  -> ProofCalldata {
+    return try!  FfiConverterTypeProofCalldata.lift(
+        try! rustCall() {
+    uniffi_mopro_ffi_fn_func_to_ethereum_proof(
+        FfiConverterData.lower(proof),$0)
+}
+    )
+}
+
 public func verifyProof2(proof: Data, publicInput: Data) throws -> Bool {
     return try  FfiConverterBool.lift(
         try rustCallWithError(FfiConverterTypeMoproError.lift) {
@@ -1067,12 +1067,6 @@ private var initializationResult: InitializationResult {
     if (uniffi_mopro_ffi_checksum_func_add() != 8411) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_mopro_ffi_checksum_func_convert_inputs() != 59191) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_mopro_ffi_checksum_func_convert_proof() != 6119) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_mopro_ffi_checksum_func_generate_proof2() != 40187) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -1086,6 +1080,12 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mopro_ffi_checksum_func_run_msm_benchmark() != 7930) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mopro_ffi_checksum_func_to_ethereum_inputs() != 30405) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mopro_ffi_checksum_func_to_ethereum_proof() != 60110) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mopro_ffi_checksum_func_verify_proof2() != 37192) {

--- a/mopro-ios/MoproKit/Include/moproFFI.h
+++ b/mopro-ios/MoproKit/Include/moproFFI.h
@@ -76,10 +76,6 @@ int8_t uniffi_mopro_ffi_fn_method_moprocircom_verify_proof(void*_Nonnull ptr, Ru
 );
 uint32_t uniffi_mopro_ffi_fn_func_add(uint32_t a, uint32_t b, RustCallStatus *_Nonnull out_status
 );
-RustBuffer uniffi_mopro_ffi_fn_func_convert_inputs(RustBuffer inputs, RustCallStatus *_Nonnull out_status
-);
-RustBuffer uniffi_mopro_ffi_fn_func_convert_proof(RustBuffer proof, RustCallStatus *_Nonnull out_status
-);
 RustBuffer uniffi_mopro_ffi_fn_func_generate_proof2(RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_mopro_ffi_fn_func_hello(RustCallStatus *_Nonnull out_status
@@ -91,6 +87,10 @@ void uniffi_mopro_ffi_fn_func_initialize_mopro(RustCallStatus *_Nonnull out_stat
 void uniffi_mopro_ffi_fn_func_initialize_mopro_dylib(RustBuffer dylib_path, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_mopro_ffi_fn_func_run_msm_benchmark(RustBuffer num_msm, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_mopro_ffi_fn_func_to_ethereum_inputs(RustBuffer inputs, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_mopro_ffi_fn_func_to_ethereum_proof(RustBuffer proof, RustCallStatus *_Nonnull out_status
 );
 int8_t uniffi_mopro_ffi_fn_func_verify_proof2(RustBuffer proof, RustBuffer public_input, RustCallStatus *_Nonnull out_status
 );
@@ -211,12 +211,6 @@ void ffi_mopro_ffi_rust_future_complete_void(void* _Nonnull handle, RustCallStat
 uint16_t uniffi_mopro_ffi_checksum_func_add(void
     
 );
-uint16_t uniffi_mopro_ffi_checksum_func_convert_inputs(void
-    
-);
-uint16_t uniffi_mopro_ffi_checksum_func_convert_proof(void
-    
-);
 uint16_t uniffi_mopro_ffi_checksum_func_generate_proof2(void
     
 );
@@ -230,6 +224,12 @@ uint16_t uniffi_mopro_ffi_checksum_func_initialize_mopro_dylib(void
     
 );
 uint16_t uniffi_mopro_ffi_checksum_func_run_msm_benchmark(void
+    
+);
+uint16_t uniffi_mopro_ffi_checksum_func_to_ethereum_inputs(void
+    
+);
+uint16_t uniffi_mopro_ffi_checksum_func_to_ethereum_proof(void
     
 );
 uint16_t uniffi_mopro_ffi_checksum_func_verify_proof2(void

--- a/mopro-ios/MoproKit/Include/moproFFI.h
+++ b/mopro-ios/MoproKit/Include/moproFFI.h
@@ -76,6 +76,10 @@ int8_t uniffi_mopro_ffi_fn_method_moprocircom_verify_proof(void*_Nonnull ptr, Ru
 );
 uint32_t uniffi_mopro_ffi_fn_func_add(uint32_t a, uint32_t b, RustCallStatus *_Nonnull out_status
 );
+RustBuffer uniffi_mopro_ffi_fn_func_convert_inputs(RustBuffer inputs, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_mopro_ffi_fn_func_convert_proof(RustBuffer proof, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_mopro_ffi_fn_func_generate_proof2(RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_mopro_ffi_fn_func_hello(RustCallStatus *_Nonnull out_status
@@ -85,6 +89,8 @@ void uniffi_mopro_ffi_fn_func_initialize_mopro(RustCallStatus *_Nonnull out_stat
     
 );
 void uniffi_mopro_ffi_fn_func_initialize_mopro_dylib(RustBuffer dylib_path, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_mopro_ffi_fn_func_run_msm_benchmark(RustBuffer num_msm, RustCallStatus *_Nonnull out_status
 );
 int8_t uniffi_mopro_ffi_fn_func_verify_proof2(RustBuffer proof, RustBuffer public_input, RustCallStatus *_Nonnull out_status
 );
@@ -205,6 +211,12 @@ void ffi_mopro_ffi_rust_future_complete_void(void* _Nonnull handle, RustCallStat
 uint16_t uniffi_mopro_ffi_checksum_func_add(void
     
 );
+uint16_t uniffi_mopro_ffi_checksum_func_convert_inputs(void
+    
+);
+uint16_t uniffi_mopro_ffi_checksum_func_convert_proof(void
+    
+);
 uint16_t uniffi_mopro_ffi_checksum_func_generate_proof2(void
     
 );
@@ -215,6 +227,9 @@ uint16_t uniffi_mopro_ffi_checksum_func_initialize_mopro(void
     
 );
 uint16_t uniffi_mopro_ffi_checksum_func_initialize_mopro_dylib(void
+    
+);
+uint16_t uniffi_mopro_ffi_checksum_func_run_msm_benchmark(void
     
 );
 uint16_t uniffi_mopro_ffi_checksum_func_verify_proof2(void


### PR DESCRIPTION
- core: use `ethereum::Proof` to convert proof
- ffi: convert `U256` data to `string`
- usage:
  - kotlin
     ```kotlin
     var convertProofResult = convertProof(generateProofResult.proof)
     var convertInputsResult = convertInputs(generateProofResult.inputs)
     ```
  - swift
     ```swift
     let convertProofResult = convertProof(proof: generateProofResult.proof)
     let convertInputsResult = convertInputs(inputs: generateProofResult.inputs)
     ```