### PR TITLE
fix(generate_benchmark_report): main function exists even when feature is not enabled

### DIFF
--- a/mopro-core/src/middleware/gpu_explorations/bin/generate_benchmark_report.rs
+++ b/mopro-core/src/middleware/gpu_explorations/bin/generate_benchmark_report.rs
@@ -32,3 +32,8 @@ fn main() {
         .unwrap();
     }
 }
+
+#[cfg(not(feature = "gpu-benchmarks"))]
+fn main() {
+    println!("The gpu-benchmarks feature is not enabled.");
+}


### PR DESCRIPTION
FIx of the issue in https://github.com/oskarth/mopro/issues/61#issue-2104544124.

The main problem is that `./scripts/build_ios.sh simulator release` run `cargo build --release`. The build process can now be successfully executed and so is the script.