### PR TITLE
feat: Use TOML for config

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Prepare CI for iOS
         run: ./scripts/prepare_ci.sh
       - name: Build for iOS
-        run: ./scripts/build_ios.sh x86_64 debug
+        run: ./scripts/build_ios.sh config-example.toml
       - name: Run iOS tests
         run: |
           cd mopro-ios/MoproKit/Example
@@ -51,7 +51,7 @@ jobs:
       - name: Prepare CI for Core and FFI
         run: ./scripts/prepare_ci.sh
       - name: Build for Android
-        run: ./scripts/build_android.sh arm64 debug
+        run: ./scripts/build_android.sh config-example-android.toml
       - name: Run core tests
         run: cd mopro-core && cargo test -- --nocapture
       - name: Run FFI tests

--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ Zooming in a bit:
 
 (Note that we require `uniffi-bindgen` to be `0.25`, if you have an older version you might need to remove this to re-install the latest).
 
+### Configure settings
+
+By creating a `toml` configuration file you can specify what build settings you want to use. Example is provided in `config-example.toml`:
+
+```
+# config-example.toml
+
+[build]
+# For iOS device_type can be x86_64, simulator, device
+# For Android device_type can be x86_64, arm, arm64
+device_type = "simulator" # Options: x86_64, simulator, device, arm, arm64
+
+# debug is for Rust library to be in debug mode and release for release mode
+# We recommend release mode by default for performance
+build_mode = "release"    # Options: debug, release
+
+[circuit]
+dir = "examples/circom/keccak256" # Directory of the circuit
+name = "keccak256_256_test"       # Name of the circuit
+
+[dylib]
+use_dylib = true         # Options: true, false
+name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true
+```
+
 ### iOS
 
 #### Prepare
@@ -39,20 +64,17 @@ Zooming in a bit:
 
 #### Build Bindings
 
-To build bindings for iOS simulator debug mode, run
+To build bindings for iOS, adjust settings in your config file (we recommend starting with `simulator` and `release`) and run:
 
 ```sh
-./scripts/build_ios.sh simulator debug
+./scripts/build_ios.sh config-example.toml
 ```
 
 Open the `mopro-ios/MoproKit/Example/MoproKit.xcworkspace` in Xcode.
 
 #### Update Bindings
 
-To update bindings, run `./scripts/update_bindings.sh simulator|device debug|release`.
-
--   `simulator` is for building library to run on iOS simulator, `device` is for running on a real device
--   `debug` is for Rust library to be in debug mode and `release` for release mode
+To update bindings, run `./scripts/update_bindings.sh config-example`.
 
 ### Android
 
@@ -80,7 +102,7 @@ To update bindings, run `./scripts/update_bindings.sh simulator|device debug|rel
 To build bindings for android simulator debug mode, run
 
 ```sh
-./scripts/build_android.sh arm64 debug
+./scripts/build_android.sh config-example.toml
 ```
 
 - **Device types:** `x86_64`, `x86`, `arm`, `arm64`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ dir = "examples/circom/keccak256" # Directory of the circuit
 name = "keccak256_256_test"       # Name of the circuit
 
 [dylib]
-use_dylib = true         # Options: true, false
+use_dylib = false         # Options: true, false
 name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true
 ```
 

--- a/config-example-android.toml
+++ b/config-example-android.toml
@@ -1,0 +1,22 @@
+# config-example-android.toml
+
+# Android specific configuration
+
+[build]
+# For iOS device_type can be x86_64, simulator, device
+# For Android device_type can be x86_64, arm, arm64
+device_type = "arm64" # Options: x86_64, simulator, device, arm, arm64
+
+# debug is for Rust library to be in debug mode and release for release mode
+# We recommend release mode by default for performance
+build_mode = "debug" # Options: debug, release
+
+[circuit]
+dir = "examples/circom/keccak256" # Directory of the circuit
+name = "keccak256_256_test"       # Name of the circuit
+
+[dylib]
+# NOTE: Dylib support is experimental and requires some fiddling in iOS
+# See https://github.com/oskarth/mopro/pull/37 and https://github.com/oskarth/mopro/pull/38
+use_dylib = false        # Options: true, false
+name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true

--- a/config-example.toml
+++ b/config-example.toml
@@ -1,0 +1,5 @@
+# config-example.toml
+
+[build]
+device_type = "simulator" # Options: x86_64, simulator, device
+build_mode = "release"    # Options: debug, release

--- a/config-example.toml
+++ b/config-example.toml
@@ -14,5 +14,7 @@ dir = "examples/circom/keccak256" # Directory of the circuit
 name = "keccak256_256_test"       # Name of the circuit
 
 [dylib]
-use_dylib = true         # Options: true, false
+# NOTE: Dylib support is experimental and requires some fiddling in iOS
+# See https://github.com/oskarth/mopro/pull/37 and https://github.com/oskarth/mopro/pull/38
+use_dylib = false        # Options: true, false
 name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true

--- a/config-example.toml
+++ b/config-example.toml
@@ -3,3 +3,11 @@
 [build]
 device_type = "simulator" # Options: x86_64, simulator, device
 build_mode = "release"    # Options: debug, release
+
+[circuit]
+dir = "examples/circom/keccak256" # Directory of the circuit
+name = "keccak256_256_test"       # Name of the circuit
+
+[dylib]
+use_dylib = false        # Options: true, false
+name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true

--- a/config-example.toml
+++ b/config-example.toml
@@ -1,13 +1,18 @@
 # config-example.toml
 
 [build]
-device_type = "simulator" # Options: x86_64, simulator, device
-build_mode = "release"    # Options: debug, release
+# For iOS device_type can be x86_64, simulator, device
+# For Android device_type can be x86_64, arm, arm64
+device_type = "simulator" # Options: x86_64, simulator, device, arm, arm64
+
+# debug is for Rust library to be in debug mode and release for release mode
+# We recommend release mode by default for performance
+build_mode = "release" # Options: debug, release
 
 [circuit]
 dir = "examples/circom/keccak256" # Directory of the circuit
 name = "keccak256_256_test"       # Name of the circuit
 
 [dylib]
-use_dylib = false        # Options: true, false
+use_dylib = true         # Options: true, false
 name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true

--- a/mopro-core/Cargo.toml
+++ b/mopro-core/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 wasmer = { git = "https://github.com/oskarth/wasmer.git", rev = "09c7070" }
 
 [features]
-default = []
-dylib = ["wasmer/dylib"]
+default = ["wasmer/dylib"]
+dylib = []                                        # NOTE: can probably remove this if we use env config instead
 gpu-benchmarks = ["jemalloc-ctl", "jemallocator"]
 
 [dependencies]

--- a/mopro-core/Cargo.toml
+++ b/mopro-core/Cargo.toml
@@ -47,13 +47,16 @@ color-eyre = "=0.6.2"
 criterion = "=0.3.6"
 
 # GPU benchmarks
-jemalloc-ctl = { version = "0.5.4", optional = true}
-jemallocator = { version = "0.5.4", optional = true}
+jemalloc-ctl = { version = "0.5.4", optional = true }
+jemallocator = { version = "0.5.4", optional = true }
 
 [build-dependencies]
 color-eyre = "0.6"
 enumset = "1.0.8"
 wasmer = { git = "https://github.com/oskarth/wasmer.git", rev = "09c7070" }
+toml = "0.8"
+serde = "1.0"
+serde_derive = "1.0"
 
 [[bin]]
 name = "generate_benchmark_report"

--- a/mopro-core/build.rs
+++ b/mopro-core/build.rs
@@ -1,6 +1,26 @@
 use color_eyre::eyre::Result;
+use serde::Deserialize;
 use std::env;
+use std::fs;
 use std::path::PathBuf;
+use toml;
+
+#[derive(Deserialize)]
+struct Config {
+    circuit: CircuitConfig,
+    dylib: DylibConfig,
+}
+
+#[derive(Deserialize)]
+struct CircuitConfig {
+    dir: String,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct DylibConfig {
+    name: String,
+}
 
 fn prepare_env(zkey_path: String, wasm_path: String, arkzkey_path: String) -> Result<()> {
     let project_dir = env::var("CARGO_MANIFEST_DIR")?;
@@ -77,7 +97,25 @@ fn build_dylib(wasm_path: String, dylib_name: String) -> Result<()> {
     Ok(())
 }
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Read and parse the TOML configuration file
+    let config_path =
+        env::var("BUILD_CONFIG_PATH").unwrap_or_else(|_| "config-example.toml".to_string());
+    let config_str = fs::read_to_string(config_path)?;
+    let config: Config = toml::from_str(&config_str)?;
+
+    // Use values from the configuration
+    let dir = &config.circuit.dir;
+    let circuit = &config.circuit.name;
+    let dylib_name = &config.dylib.name;
+
+    // TODO: Actually use these values!
+
+    println!("cargo:warning=TOML config path: {}", config_str);
+    println!("cargo:warning=dir: {}", dir);
+    println!("cargo:warning=circuit: {}", circuit);
+    println!("cargo:warning=dylib_name: {}", dylib_name);
+
     // TODO: build_circuit function to builds all related artifacts, instead of doing this externally
     let dir = "examples/circom/keccak256";
     let circuit = "keccak256_256_test";

--- a/mopro-core/build.rs
+++ b/mopro-core/build.rs
@@ -1,14 +1,13 @@
 use color_eyre::eyre::Result;
 use serde::Deserialize;
-use std::env;
-use std::fs;
 use std::path::PathBuf;
+use std::{env, fs};
 use toml;
 
 #[derive(Deserialize)]
 struct Config {
     circuit: CircuitConfig,
-    dylib: DylibConfig,
+    dylib: Option<DylibConfig>,
 }
 
 #[derive(Deserialize)]
@@ -19,35 +18,13 @@ struct CircuitConfig {
 
 #[derive(Deserialize)]
 struct DylibConfig {
+    use_dylib: bool,
     name: String,
 }
 
-fn prepare_env(zkey_path: String, wasm_path: String, arkzkey_path: String) -> Result<()> {
-    let project_dir = env::var("CARGO_MANIFEST_DIR")?;
-    let zkey_file = PathBuf::from(&project_dir).join(zkey_path);
-    let wasm_file = PathBuf::from(&project_dir).join(wasm_path);
-    let arkzkey_file = PathBuf::from(&project_dir).join(arkzkey_path);
-
-    // TODO: Right now emitting as warnings for visibility, figure out better way to do this?
-    println!("cargo:warning=zkey_file: {}", zkey_file.display());
-    println!("cargo:warning=wasm_file: {}", wasm_file.display());
-    println!("cargo:warning=arkzkey_file: {}", arkzkey_file.display());
-
-    // Set BUILD_RS_ZKEY_FILE and BUILD_RS_WASM_FILE env var
-    println!("cargo:rustc-env=BUILD_RS_ZKEY_FILE={}", zkey_file.display());
-    println!("cargo:rustc-env=BUILD_RS_WASM_FILE={}", wasm_file.display());
-    println!(
-        "cargo:rustc-env=BUILD_RS_ARKZKEY_FILE={}",
-        arkzkey_file.display()
-    );
-
-    Ok(())
-}
-
-#[cfg(feature = "dylib")]
 fn build_dylib(wasm_path: String, dylib_name: String) -> Result<()> {
     use std::path::Path;
-    use std::{fs, str::FromStr};
+    use std::str::FromStr;
 
     use color_eyre::eyre::eyre;
     use enumset::enum_set;
@@ -96,47 +73,83 @@ fn build_dylib(wasm_path: String, dylib_name: String) -> Result<()> {
 
     Ok(())
 }
+fn build_circuit(config: &Config) -> Result<()> {
+    let project_dir = env::var("CARGO_MANIFEST_DIR")?;
+    let circuit_dir = &config.circuit.dir;
+    let circuit_name = &config.circuit.name;
+
+    let zkey_path = PathBuf::from(&project_dir).join(format!(
+        "{}/target/{}_final.zkey",
+        circuit_dir, circuit_name
+    ));
+    let wasm_path = PathBuf::from(&project_dir).join(format!(
+        "{}/target/{}_js/{}.wasm",
+        circuit_dir, circuit_name, circuit_name
+    ));
+    let arkzkey_path = PathBuf::from(&project_dir).join(format!(
+        "{}/target/{}_final.arkzkey",
+        circuit_dir, circuit_name
+    ));
+
+    println!("cargo:warning=zkey_file: {}", zkey_path.display());
+    println!("cargo:warning=wasm_file: {}", wasm_path.display());
+    println!("cargo:warning=arkzkey_file: {}", arkzkey_path.display());
+
+    // Set BUILD_RS_* environment variables
+    println!("cargo:rustc-env=BUILD_RS_ZKEY_FILE={}", zkey_path.display());
+    println!("cargo:rustc-env=BUILD_RS_WASM_FILE={}", wasm_path.display());
+    println!(
+        "cargo:rustc-env=BUILD_RS_ARKZKEY_FILE={}",
+        arkzkey_path.display()
+    );
+
+    Ok(())
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Read and parse the TOML configuration file
-    let config_path =
-        env::var("BUILD_CONFIG_PATH").unwrap_or_else(|_| "config-example.toml".to_string());
-    let config_str = fs::read_to_string(config_path)?;
+    let config_str = match env::var("BUILD_CONFIG_PATH") {
+        Ok(config_path) => {
+            println!("cargo:warning=config: {}", config_path);
+            fs::read_to_string(config_path)?
+        }
+        Err(_) => {
+            println!("cargo:warning=BUILD_CONFIG_PATH not set. Using default configuration.");
+            // Default configuration
+            let default_config = r#"
+                    [circuit]
+                    dir = "examples/circom/keccak256"
+                    name = "keccak256_256_test"
+    
+                    #[dylib]
+                    use_dlib = false
+                    #name = "keccak256.dylib"
+                "#;
+            default_config.to_string()
+        }
+    };
+
     let config: Config = toml::from_str(&config_str)?;
 
-    // Use values from the configuration
-    let dir = &config.circuit.dir;
-    let circuit = &config.circuit.name;
-    let dylib_name = &config.dylib.name;
+    // Build circuit
+    build_circuit(&config)?;
 
-    // TODO: Actually use these values!
-
-    println!("cargo:warning=TOML config path: {}", config_str);
-    println!("cargo:warning=dir: {}", dir);
-    println!("cargo:warning=circuit: {}", circuit);
-    println!("cargo:warning=dylib_name: {}", dylib_name);
-
-    // TODO: build_circuit function to builds all related artifacts, instead of doing this externally
-    let dir = "examples/circom/keccak256";
-    let circuit = "keccak256_256_test";
-
-    // XXX: Use RSA
-    // let dir = "examples/circom/rsa";
-    // let circuit = "main";
-
-    let zkey_path = format!("{}/target/{}_final.zkey", dir, circuit);
-    let wasm_path = format!("{}/target/{}_js/{}.wasm", dir, circuit, circuit);
-    // TODO: Need to modify script for this
-    let arkzkey_path = format!("{}/target/{}_final.arkzkey", dir, circuit);
-
-    prepare_env(zkey_path, wasm_path.clone(), arkzkey_path)?;
-
-    #[cfg(feature = "dylib")]
-    {
-        // TODO: This should depends on the circuit name
-        //let dylib_name = "keccak256.dylib";
-        let dylib_name = "rsa.dylib";
-        build_dylib(wasm_path.clone(), dylib_name.to_string())?;
+    // Build dylib if enabled
+    if let Some(dylib_config) = &config.dylib {
+        if dylib_config.use_dylib {
+            println!("cargo:warning=Building dylib: {}", dylib_config.name);
+            build_dylib(
+                config.circuit.dir.clone()
+                    + "/target/"
+                    + &config.circuit.name
+                    + "_js/"
+                    + &config.circuit.name
+                    + ".wasm",
+                dylib_config.name.clone(),
+            )?;
+        } else {
+            println!("cargo:warning=Dylib usage is disabled in the config.");
+        }
     }
+
     Ok(())
 }

--- a/scripts/_prelude.sh
+++ b/scripts/_prelude.sh
@@ -1,0 +1,48 @@
+# _prelude.sh
+# Commonly used shell utilities and functions, shared across scripts.
+
+# Deal with errors
+set -euo pipefail
+
+# Color definitions
+DEFAULT='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+GREY='\033[0;90m'
+
+# NOTE: This is quite noisy so turning off by default
+# Coloring the -x output (commands)
+#DEBUG_COLOR="${DEFAULT}"
+#trap 'echo -e ${DEBUG_COLOR}${BASH_COMMAND}${DEFAULT}' DEBUG
+
+# Function to handle exit
+handle_exit() {
+    # $? is a special variable that holds the exit code of the last command executed
+    if [ $? -ne 0 ]; then
+        echo -e "\n${RED}Script did not finish successfully!${DEFAULT}"
+    fi
+}
+
+# Set the trap
+trap handle_exit EXIT
+
+print_action() {
+    printf "\n${GREEN}$1${DEFAULT}\n"
+}
+
+print_warning() {
+    printf "\n${YELLOW}$1${DEFAULT}\n"
+}
+
+# Check if toml-cli is installed
+if ! command -v toml &> /dev/null; then
+    echo -e "${RED}toml (toml-cli) is not installed. Please install it to continue.${DEFAULT}"
+    exit 1
+fi
+
+# Function to read value from TOML file and remove quotes
+read_toml() {
+    toml get "$1" "$2" | tr -d '"'
+}

--- a/scripts/_prelude.sh
+++ b/scripts/_prelude.sh
@@ -35,14 +35,3 @@ print_action() {
 print_warning() {
     printf "\n${YELLOW}$1${DEFAULT}\n"
 }
-
-# Check if toml-cli is installed
-if ! command -v toml &> /dev/null; then
-    echo -e "${RED}toml (toml-cli) is not installed. Please install it to continue.${DEFAULT}"
-    exit 1
-fi
-
-# Function to read value from TOML file and remove quotes
-read_toml() {
-    toml get "$1" "$2" | tr -d '"'
-}

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -1,31 +1,7 @@
 #!/bin/bash
 
-PROJECT_DIR=$(pwd)
-
-# Color definitions
-DEFAULT='\033[0m'
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-
-# Function to handle exit
-handle_exit() {
-    # $? is a special variable that holds the exit code of the last command executed
-    if [ $? -ne 0 ]; then
-        echo -e "\n${RED}Script did not finish successfully!${DEFAULT}"
-    fi
-}
-
-# Set the trap
-trap handle_exit EXIT
-
-print_action() {
-    printf "\n${GREEN}$1${DEFAULT}\n"
-}
-
-print_warning() {
-    printf "\n${YELLOW}$1${DEFAULT}\n"
-}
+# Source the script prelude
+source "scripts/_prelude.sh"
 
 # Check for the device type argument
 if [[ "$1" == "x86_64" ]]; then
@@ -59,6 +35,7 @@ else
     exit 1
 fi
 
+PROJECT_DIR=$(pwd)
 cd ${PROJECT_DIR}/mopro-ffi
 
 # Print appropriate message based on device type

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -3,6 +3,17 @@
 # Source the script prelude
 source "scripts/_prelude.sh"
 
+# Check if toml-cli is installed
+if ! command -v toml &> /dev/null; then
+    echo -e "${RED}toml (toml-cli) is not installed. Please install it to continue.${DEFAULT}"
+    exit 1
+fi
+
+# Function to read value from TOML file and remove quotes
+read_toml() {
+    toml get "$1" "$2" | tr -d '"'
+}
+
 # Check if a configuration file was passed as an argument
 if [ "$#" -ne 1 ]; then
     echo -e "\n${RED}Usage: $0 path/to/config.toml${DEFAULT}"

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -1,30 +1,7 @@
 #!/bin/bash
 
-# Color definitions
-DEFAULT='\033[0m'
-RED='\033[0;31m'
-
-# Function to handle exit
-handle_exit() {
-    # $? is a special variable that holds the exit code of the last command executed
-    if [ $? -ne 0 ]; then
-        echo -e "\n${RED}Script did not finish successfully!${DEFAULT}"
-    fi
-}
-
-# Set the trap
-trap handle_exit EXIT
-
-# Check if toml-cli is installed
-if ! command -v toml &> /dev/null; then
-    echo -e "\n${RED}toml-cli is not installed. Please install it to continue.${DEFAULT}"
-    exit 1
-fi
-
-# Function to read value from TOML file and remove quotes
-read_toml() {
-    toml get "$1" "$2" | tr -d '"'
-}
+# Source the script prelude
+source "scripts/_prelude.sh"
 
 # Check if a configuration file was passed as an argument
 if [ "$#" -ne 1 ]; then
@@ -73,7 +50,6 @@ case $BUILD_MODE in
         ;;
 esac
 
-# Rest of the script
 PROJECT_DIR=$(pwd)
 
 # Build circom circuits in mopro-core

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -3,6 +3,17 @@
 # Source the script prelude
 source "scripts/_prelude.sh"
 
+# Check if toml-cli is installed
+if ! command -v toml &> /dev/null; then
+    echo -e "${RED}toml (toml-cli) is not installed. Please install it to continue.${DEFAULT}"
+    exit 1
+fi
+
+# Function to read value from TOML file and remove quotes
+read_toml() {
+    toml get "$1" "$2" | tr -d '"'
+}
+
 # Check if a configuration file was passed as an argument
 if [ "$#" -ne 1 ]; then
     echo -e "\n${RED}Usage: $0 path/to/config.toml${DEFAULT}"

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -66,7 +66,7 @@ pod install
 
 # Update bindings
 cd "${PROJECT_DIR}"
-./scripts/update_bindings.sh $DEVICE_TYPE $BUILD_MODE
+./scripts/update_bindings.sh $CONFIG_FILE
 
 # Update xcconfig
 MODES="debug release"

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -12,6 +12,9 @@ fi
 # Read the path to the TOML configuration file from the first argument
 CONFIG_FILE="$1"
 
+# Export the configuration file path as an environment variable
+export BUILD_CONFIG_PATH="$(pwd)/$CONFIG_FILE"
+
 # Print which configuration file is being used
 echo "Using configuration file: $CONFIG_FILE"
 

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,38 +1,7 @@
 #!/bin/bash
 
-# Deal with errors
-set -euo pipefail
-
-# Color definitions
-DEFAULT='\033[0m'
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-BLUE='\033[0;34m'
-GREY='\033[0;90m'
-
-# Coloring the -x output (commands)
-# DEBUG_COLOR="${DEFAULT}"
-# trap 'echo -e ${DEBUG_COLOR}${BASH_COMMAND}${DEFAULT}' DEBUG
-
-# Function to handle exit
-handle_exit() {
-    # $? is a special variable that holds the exit code of the last command executed
-    if [ $? -ne 0 ]; then
-        echo -e "\n${RED}Script did not finish successfully!${DEFAULT}"
-    fi
-}
-
-# Set the trap
-trap handle_exit EXIT
-
-print_action() {
-    printf "\n${GREEN}$1${DEFAULT}\n"
-}
-
-print_warning() {
-    printf "\n${YELLOW}$1${DEFAULT}\n"
-}
+# Source the script prelude
+source "scripts/_prelude.sh"
 
 # Assert we're in the project root
 if [[ ! -d "mopro-ffi" || ! -d "mopro-core" || ! -d "mopro-ios" ]]; then

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -141,6 +141,15 @@ else
     echo "uniffi-bindgen already installed, skipping."
 fi
 
+# Install toml-cli binary
+print_action "[config] Installing toml-cli..."
+if ! command -v toml &> /dev/null
+then
+    cargo install toml-cli
+else
+    echo "toml already installed, skipping."
+fi
+
 # Check uniffi-bindgen version
 print_action "[ffi] Checking uniffi-bindgen version..."
 UNIFFI_VERSION=$(uniffi-bindgen --version | grep -oE '0\.25\.[0-9]+' || echo "not found")

--- a/scripts/prepare_ci.sh
+++ b/scripts/prepare_ci.sh
@@ -1,38 +1,7 @@
 #!/bin/bash
 
-# Deal with errors
-set -euo pipefail
-
-# Color definitions
-DEFAULT='\033[0m'
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-BLUE='\033[0;34m'
-GREY='\033[0;90m'
-
-# Coloring the -x output (commands)
-# DEBUG_COLOR="${DEFAULT}"
-# trap 'echo -e ${DEBUG_COLOR}${BASH_COMMAND}${DEFAULT}' DEBUG
-
-# Function to handle exit
-handle_exit() {
-    # $? is a special variable that holds the exit code of the last command executed
-    if [ $? -ne 0 ]; then
-        echo -e "\n${RED}Script did not finish successfully!${DEFAULT}"
-    fi
-}
-
-# Set the trap
-trap handle_exit EXIT
-
-print_action() {
-    printf "\n${GREEN}$1${DEFAULT}\n"
-}
-
-print_warning() {
-    printf "\n${YELLOW}$1${DEFAULT}\n"
-}
+# Source the script prelude
+source "scripts/_prelude.sh"
 
 # Assert we're in the project root
 if [[ ! -d "mopro-ffi" || ! -d "mopro-core" || ! -d "mopro-ios" ]]; then

--- a/scripts/prepare_ci.sh
+++ b/scripts/prepare_ci.sh
@@ -131,13 +131,4 @@ else
     echo "uniffi-bindgen already installed, skipping."
 fi
 
-# Install toml-cli binary
-print_action "[config] Installing toml-cli..."
-if ! command -v toml &> /dev/null
-then
-    cargo install toml-cli
-else
-    echo "toml already installed, skipping."
-fi
-
 print_action "Done! Please run ./scripts/buld_ios.sh to build for iOS."

--- a/scripts/prepare_ci.sh
+++ b/scripts/prepare_ci.sh
@@ -122,6 +122,15 @@ for target in x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim; do
     fi
 done
 
+# Install toml-cli binary
+print_action "[config] Installing toml-cli..."
+if ! command -v toml &> /dev/null
+then
+    cargo install toml-cli
+else
+    echo "toml already installed, skipping."
+fi
+
 # Install uniffi-bindgen binary in mopro-ffi
 print_action "[ffi] Installing uniffi-bindgen..."
 if ! command -v uniffi-bindgen &> /dev/null

--- a/scripts/prepare_ci.sh
+++ b/scripts/prepare_ci.sh
@@ -131,4 +131,13 @@ else
     echo "uniffi-bindgen already installed, skipping."
 fi
 
+# Install toml-cli binary
+print_action "[config] Installing toml-cli..."
+if ! command -v toml &> /dev/null
+then
+    cargo install toml-cli
+else
+    echo "toml already installed, skipping."
+fi
+
 print_action "Done! Please run ./scripts/buld_ios.sh to build for iOS."

--- a/scripts/update_bindings.sh
+++ b/scripts/update_bindings.sh
@@ -3,6 +3,17 @@
 # Source the script prelude
 source "scripts/_prelude.sh"
 
+# Check if toml-cli is installed
+if ! command -v toml &> /dev/null; then
+    echo -e "${RED}toml (toml-cli) is not installed. Please install it to continue.${DEFAULT}"
+    exit 1
+fi
+
+# Function to read value from TOML file and remove quotes
+read_toml() {
+    toml get "$1" "$2" | tr -d '"'
+}
+
 # NOTE: This is quite noisy so turning off by default
 # Coloring the -x output (commands)
 DEBUG_COLOR="${DEFAULT}"

--- a/scripts/update_bindings.sh
+++ b/scripts/update_bindings.sh
@@ -1,38 +1,7 @@
 #!/bin/bash
 
-# Deal with errors
-set -euo pipefail
-
-# Color definitions
-DEFAULT='\033[0m'
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-BLUE='\033[0;34m'
-GREY='\033[0;90m'
-
-# Coloring the -x output (commands)
-DEBUG_COLOR="${DEFAULT}"
-trap 'echo -e ${DEBUG_COLOR}${BASH_COMMAND}${DEFAULT}' DEBUG
-
-# Function to handle exit
-handle_exit() {
-    # $? is a special variable that holds the exit code of the last command executed
-    if [ $? -ne 0 ]; then
-        echo -e "\n${RED}Script did not finish successfully!${DEFAULT}"
-    fi
-}
-
-# Set the trap
-trap handle_exit EXIT
-
-print_action() {
-    printf "\n${GREEN}$1${DEFAULT}\n"
-}
-
-print_warning() {
-    printf "\n${YELLOW}$1${DEFAULT}\n"
-}
+# Source the script prelude
+source "scripts/_prelude.sh"
 
 # Assert we're in the project root
 if [[ ! -d "mopro-ffi" || ! -d "mopro-core" || ! -d "mopro-ios" ]]; then

--- a/scripts/update_bindings.sh
+++ b/scripts/update_bindings.sh
@@ -3,6 +3,11 @@
 # Source the script prelude
 source "scripts/_prelude.sh"
 
+# NOTE: This is quite noisy so turning off by default
+# Coloring the -x output (commands)
+DEBUG_COLOR="${DEFAULT}"
+trap 'echo -e ${DEBUG_COLOR}${BASH_COMMAND}${DEFAULT}' DEBUG
+
 # Check if a configuration file was passed as an argument
 if [ "$#" -ne 1 ]; then
     echo -e "\n${RED}Usage: $0 path/to/config.toml${DEFAULT}"
@@ -11,6 +16,9 @@ fi
 
 # Read the path to the TOML configuration file from the first argument
 CONFIG_FILE="$1"
+
+# Export the configuration file path as an environment variable
+export BUILD_CONFIG_PATH="$(pwd)/$CONFIG_FILE"
 
 # Print which configuration file is being used
 echo "Using configuration file: $CONFIG_FILE"


### PR DESCRIPTION
This PR starts to introduce a more robust way of configuring relevant build options and environment.

Currently there's a big surface area for options, and we still have some hardcoded leftovers. This means we currently have to do things like this: https://github.com/oskarth/mopro/pull/66/files/8e7d9dafaf0538ab84d739ec8a9f42437772df1a#diff-10095d80195138814b66f1d6f5b769b0763cd537d9ef563a28c6d75444a151d5 which makes things very confusing, especially when we have dealing with multiple circuits.

## Big idea

Specify options in a toml file:

```
# config-example.toml

[build]
device_type = "simulator" # Options: x86_64, simulator, device
build_mode = "release"    # Options: debug, release

[circuit]
dir = "examples/circom/keccak256" # Directory of the circuit
name = "keccak256_256_test"       # Name of the circuit

[dylib]
use_dylib = false        # Options: true, false
name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true
```

Then call this with build scripts like so:

`./scripts/build_ios.sh config-example.toml`

It is then easy to introduce multiple configs (e.g. for Anon-Aadhaar), to debug etc.

TOML config is also a good way to prepare for Rust API. I made it work for shell scripts too since that's the current base.

## TODO before merge
- [ ] Sanity check of initial API (feedback welcome)
- [x] Get rid of hardcoded stuff in build.rs and use TOML config instead
- [x] Update Android script
- [ ] Make sure CI passes
- [x] Update README