### PR TITLE
Fix: toml config

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Prepare CI for iOS
         run: ./scripts/prepare_ci.sh
       - name: Build for iOS
-        run: ./scripts/build_ios.sh config-example.toml
+        run: ./scripts/build_ios.sh config-ci.toml
       - name: Run iOS tests
         run: |
           cd mopro-ios/MoproKit/Example

--- a/config-ci.toml
+++ b/config-ci.toml
@@ -1,0 +1,20 @@
+# config-example.toml
+
+[build]
+# For iOS device_type can be x86_64, simulator, device
+# For Android device_type can be x86_64, arm, arm64
+device_type = "x86_64" # Options: x86_64, simulator, device, arm, arm64
+
+# debug is for Rust library to be in debug mode and release for release mode
+# We recommend release mode by default for performance
+build_mode = "release" # Options: debug, release
+
+[circuit]
+dir = "examples/circom/keccak256" # Directory of the circuit
+name = "keccak256_256_test"       # Name of the circuit
+
+[dylib]
+# NOTE: Dylib support is experimental and requires some fiddling in iOS
+# See https://github.com/oskarth/mopro/pull/37 and https://github.com/oskarth/mopro/pull/38
+use_dylib = false        # Options: true, false
+name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -93,7 +93,7 @@ print_action "[core/circom] Generating arkzkey for rsa..."
 print_action "[ffi] Adding support for target architectures..."
 cd ${PROJECT_DIR}/mopro-ffi
 
-for target in x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim; do
+for target in x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android; do
     if ! check_target_support $target; then
         rustup target add $target
     else

--- a/scripts/prepare_ci.sh
+++ b/scripts/prepare_ci.sh
@@ -114,7 +114,7 @@ download_files "rsa" "main"
 print_action "[ffi] Adding support for target architectures..."
 cd ${PROJECT_DIR}/mopro-ffi
 
-for target in x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim; do
+for target in x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android; do
     if ! check_target_support $target; then
         rustup target add $target
     else


### PR DESCRIPTION
- add target check for android devices
- fix ci: the device type is `x86_64`