### PR TITLE
feat(ios): added basic UI in MSM Benchmark

### DIFF
--- a/mopro-core/src/middleware/gpu_explorations/mod.rs
+++ b/mopro-core/src/middleware/gpu_explorations/mod.rs
@@ -12,6 +12,7 @@ pub struct BenchmarkResult {
     pub total_processing_time: f64,
 }
 
+// TODO: refactor fn name and add more benchmarks in the future
 fn single_msm() -> Result<(), Box<dyn Error>> {
     let mut rng = ark_std::test_rng();
 
@@ -27,6 +28,7 @@ fn single_msm() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+// TODO: figure out a way to configure the algorithm fn used
 // Run the msm benchmark with timing
 pub fn run_msm_benchmark(num_msm: Option<u32>) -> Result<BenchmarkResult, Box<dyn Error>> {
     let num_msm = num_msm.unwrap_or(1000); // default to 1000 msm operations

--- a/mopro-ios/MoproKit/Bindings/mopro.swift
+++ b/mopro-ios/MoproKit/Bindings/mopro.swift
@@ -509,15 +509,13 @@ public struct BenchmarkResult {
     public var numMsm: UInt32
     public var avgProcessingTime: Double
     public var totalProcessingTime: Double
-    public var allocatedMemory: UInt32
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(numMsm: UInt32, avgProcessingTime: Double, totalProcessingTime: Double, allocatedMemory: UInt32) {
+    public init(numMsm: UInt32, avgProcessingTime: Double, totalProcessingTime: Double) {
         self.numMsm = numMsm
         self.avgProcessingTime = avgProcessingTime
         self.totalProcessingTime = totalProcessingTime
-        self.allocatedMemory = allocatedMemory
     }
 }
 
@@ -533,9 +531,6 @@ extension BenchmarkResult: Equatable, Hashable {
         if lhs.totalProcessingTime != rhs.totalProcessingTime {
             return false
         }
-        if lhs.allocatedMemory != rhs.allocatedMemory {
-            return false
-        }
         return true
     }
 
@@ -543,7 +538,6 @@ extension BenchmarkResult: Equatable, Hashable {
         hasher.combine(numMsm)
         hasher.combine(avgProcessingTime)
         hasher.combine(totalProcessingTime)
-        hasher.combine(allocatedMemory)
     }
 }
 
@@ -553,8 +547,7 @@ public struct FfiConverterTypeBenchmarkResult: FfiConverterRustBuffer {
         return try BenchmarkResult(
             numMsm: FfiConverterUInt32.read(from: &buf), 
             avgProcessingTime: FfiConverterDouble.read(from: &buf), 
-            totalProcessingTime: FfiConverterDouble.read(from: &buf), 
-            allocatedMemory: FfiConverterUInt32.read(from: &buf)
+            totalProcessingTime: FfiConverterDouble.read(from: &buf)
         )
     }
 
@@ -562,7 +555,6 @@ public struct FfiConverterTypeBenchmarkResult: FfiConverterRustBuffer {
         FfiConverterUInt32.write(value.numMsm, into: &buf)
         FfiConverterDouble.write(value.avgProcessingTime, into: &buf)
         FfiConverterDouble.write(value.totalProcessingTime, into: &buf)
-        FfiConverterUInt32.write(value.allocatedMemory, into: &buf)
     }
 }
 

--- a/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
+++ b/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1ECF32642B728A6F00482C55 /* MSMBenchmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ECF32632B728A6F00482C55 /* MSMBenchmarkViewController.swift */; };
 		2A418AB02AF4B1200004B747 /* CircomUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A418AAF2AF4B1200004B747 /* CircomUITests.swift */; };
 		2A6E5BAF2AF499460052A601 /* CircomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6E5BAE2AF499460052A601 /* CircomTests.swift */; };
 		4384FD09A96F702A375841EE /* Pods_MoproKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78B0F9CBE5DD22576996A993 /* Pods_MoproKit_Tests.framework */; };
@@ -46,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		1E5E014D70B48C9A59F14658 /* Pods-MoproKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoproKit_Example.release.xcconfig"; path = "Target Support Files/Pods-MoproKit_Example/Pods-MoproKit_Example.release.xcconfig"; sourceTree = "<group>"; };
+		1ECF32632B728A6F00482C55 /* MSMBenchmarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSMBenchmarkViewController.swift; sourceTree = "<group>"; };
 		2A418AAF2AF4B1200004B747 /* CircomUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomUITests.swift; sourceTree = "<group>"; };
 		2A6E5BAE2AF499460052A601 /* CircomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomTests.swift; sourceTree = "<group>"; };
 		47F8ADB0AC4168C6E874818D /* MoproKit.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = MoproKit.podspec; path = ../MoproKit.podspec; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 		607FACD21AFB9204008FA782 /* Example for MoproKit */ = {
 			isa = PBXGroup;
 			children = (
+				1ECF32632B728A6F00482C55 /* MSMBenchmarkViewController.swift */,
 				CEB804572AFF81BF0063F091 /* RSAViewController.swift */,
 				E6E6F42D2B5860F7002F5F18 /* AnonAadhaarViewControllerNew.swift */,
 				E69338632AFFDB1A00B80312 /* AnonAadhaarViewController.swift */,
@@ -416,6 +419,7 @@
 				CEB804582AFF81BF0063F091 /* RSAViewController.swift in Sources */,
 				CEB804562AFF81AF0063F091 /* KeccakZkeyViewController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
+				1ECF32642B728A6F00482C55 /* MSMBenchmarkViewController.swift in Sources */,
 				CEB804502AFF81960063F091 /* KeccakSetupViewController.swift in Sources */,
 				E6D848592B766C8C00DBAF30 /* ComplexZkeyViewController.swift in Sources */,
 				E6E6F42E2B5860F7002F5F18 /* AnonAadhaarViewControllerNew.swift in Sources */,

--- a/mopro-ios/MoproKit/Example/MoproKit/MSMBenchmarkViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/MSMBenchmarkViewController.swift
@@ -10,40 +10,84 @@ import UIKit
 import MoproKit
 
 class MSMBenchmarkViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-    
+
+    struct AlgorithmBenchmark {
+        var algorithm: String
+        var avgMsmTime: Double
+        var diffWithBaseline: Double    // Baseline is Arkwork Vanilla MSM
+    }
+
     var tableView: UITableView!
-    var submitButton: UIButton!
-    
-    let algorithms = ["1. Arkwork MSM", "2. ", "3. "]
-    var selectedAlgorithms: Set<Int> = []
-    
-    // for benchmark results
-    var resultsView: UIView!
     var resultsTableView: UITableView!
-    var benchmarkResults: [BenchmarkResult] = []
+    var submitButton: UIButton!
+
+    let algorithms = ["Arkwork MSM", "Example Algo 1", "Example Algo 2"]
+    var selectedAlgorithms: Set<Int> = []
+
+    var benchmarkResults: [AlgorithmBenchmark] = []
     
     typealias BenchmarkClosure = () throws -> BenchmarkResult
     
+    // update the mapping with function in the future
     let msmBenchmarkMapping: [String: (UInt32?) throws -> BenchmarkResult] = [
-        // update the mapping with function in the future
-        "1. Arkwork MSM": runMsmBenchmark,
-//        "2. ": msmFunction2,
-//        "3. ": msmFunction3,
+        "Arkwork MSM": runMsmBenchmark,
+        // "Example Algo 1": ,
+        // "Example Algo 2": ,
     ]
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Set title
+        let title = UILabel()
+        title.text = "MSM Benchmark"
+        title.textColor = .white
+        title.textAlignment = .center
+        navigationItem.titleView = title
+        navigationController?.navigationBar.isHidden = false
+        navigationController?.navigationBar.prefersLargeTitles = true
+
         setupTableView()
         setupBenchmarkButton()
+        setupResultsTableView()
     }
     
     func setupTableView() {
-        tableView = UITableView(frame: view.bounds)
+        tableView = UITableView()
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
-        tableView.allowsMultipleSelection = true // Enable multiple selection
+        tableView.allowsMultipleSelection = true
+        tableView.backgroundColor = .black
+        tableView.translatesAutoresizingMaskIntoConstraints = false // Disable autoresizing mask to enable auto layout
         view.addSubview(tableView)
+
+        // Set Auto Layout constraints
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor) // Adjusts to half the view's height
+        ])
+    }
+
+    func setupResultsTableView() {
+        resultsTableView = UITableView()
+        resultsTableView.delegate = self
+        resultsTableView.dataSource = self
+        resultsTableView.register(BenchmarkResultCell.self, forCellReuseIdentifier: "BenchmarkResultCell")
+        resultsTableView.allowsSelection = false
+        resultsTableView.backgroundColor = .black
+        resultsTableView.translatesAutoresizingMaskIntoConstraints = false // Disable autoresizing mask to enable auto layout
+        view.addSubview(resultsTableView)
+
+        // Set Auto Layout constraints
+        NSLayoutConstraint.activate([
+            resultsTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor),
+            resultsTableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            resultsTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            resultsTableView.bottomAnchor.constraint(equalTo: submitButton.topAnchor, constant: -20)
+        ])
     }
     
     func setupBenchmarkButton() {
@@ -54,29 +98,61 @@ class MSMBenchmarkViewController: UIViewController, UITableViewDelegate, UITable
         submitButton.backgroundColor = .systemBlue
         submitButton.setTitleColor(.white, for: .normal)
         submitButton.layer.cornerRadius = 10
+        submitButton.translatesAutoresizingMaskIntoConstraints = false // Disable autoresizing mask to enable auto layout
         view.addSubview(submitButton)
+
+        // Set Auto Layout constraints
+        NSLayoutConstraint.activate([
+            submitButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            submitButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            submitButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+            submitButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
     }
     
     // UITableViewDataSource methods
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return algorithms.count
+        if tableView == self.tableView {
+            return algorithms.count
+        } else {    // Results table
+            return benchmarkResults.count
+        }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        cell.textLabel?.text = algorithms[indexPath.row]
-        
-        if selectedAlgorithms.contains(indexPath.row) {
-            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
-            cell.accessoryType = .checkmark
-        } else {
-            cell.accessoryType = .none
+        if tableView == self.tableView {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+            cell.textLabel?.text = "\(indexPath.row + 1). \(algorithms[indexPath.row])"
+            cell.backgroundColor = .black
+            cell.textLabel?.textColor = .white
+            
+            if selectedAlgorithms.contains(indexPath.row) {
+                tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+                cell.accessoryType = .checkmark
+            } else {
+                cell.accessoryType = .none
+            }
+            return cell
+        } else {   // Results table
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: "BenchmarkResultCell", for: indexPath) as? BenchmarkResultCell else {
+                return UITableViewCell()
+            }
+            
+            let result = benchmarkResults[indexPath.row]
+            cell.nameLabel.text = result.algorithm
+            cell.avgTimeLabel.text = String(format: "%.2f ms", result.avgMsmTime)
+            cell.diffLabel.text = String(format: "%+.2f ms", result.diffWithBaseline)
+            
+            // Adjust the font size or other properties as needed
+            cell.nameLabel.font = UIFont.systemFont(ofSize: 14)
+            cell.avgTimeLabel.font = UIFont.systemFont(ofSize: 14)
+            cell.diffLabel.font = UIFont.systemFont(ofSize: 14)
+            
+            return cell
         }
-        return cell
     }
     
-    // UITableViewDelegate methods
+    // UITableViewDelegate methods for algorithm selection
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         selectedAlgorithms.insert(indexPath.row)
         if let cell = tableView.cellForRow(at: indexPath) {
@@ -92,21 +168,161 @@ class MSMBenchmarkViewController: UIViewController, UITableViewDelegate, UITable
         }
         print("Deselected: \(algorithms[indexPath.row])")
     }
-    
+
+    // UITableViewDelegate methods for header view
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let headerView = UIView()
+        headerView.backgroundColor = UIColor.black
+        
+        // Create the header label
+        let headerLabel = UILabel()
+        headerLabel.textColor = .white
+        headerLabel.font = UIFont.systemFont(ofSize: 16, weight: .bold)
+        
+        // Create the horizontal white line view
+        let lineView = UIView()
+        lineView.backgroundColor = .white // Set the line color
+        headerView.addSubview(lineView) // Add the line view to the header view
+        lineView.translatesAutoresizingMaskIntoConstraints = false
+        
+        if tableView == self.tableView {
+            headerLabel.text = "Select Algorithms"
+        } else {    // Results table
+            // Define additional labels for each column if it's the results table
+            let nameLabel = UILabel()
+            configureHeaderLabel(label: nameLabel, text: "Algo Name")
+            
+            let avgTimingLabel = UILabel()
+            configureHeaderLabel(label: avgTimingLabel, text: "Avg Timing")
+            
+            let diffLabel = UILabel()
+            configureHeaderLabel(label: diffLabel, text: "Diff with Baseline")
+            
+            // Add additional labels to the header view
+            headerView.addSubview(nameLabel)
+            headerView.addSubview(avgTimingLabel)
+            headerView.addSubview(diffLabel)
+            
+            // Disable autoresizing mask to enable auto layout
+            nameLabel.translatesAutoresizingMaskIntoConstraints = false
+            avgTimingLabel.translatesAutoresizingMaskIntoConstraints = false
+            diffLabel.translatesAutoresizingMaskIntoConstraints = false
+            
+            // Set Auto Layout constraints
+            NSLayoutConstraint.activate([
+                nameLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 8),
+                nameLabel.topAnchor.constraint(equalTo: headerView.topAnchor),
+                nameLabel.bottomAnchor.constraint(equalTo: lineView.topAnchor, constant: -8),
+                
+                avgTimingLabel.centerXAnchor.constraint(equalTo: headerView.centerXAnchor),
+                avgTimingLabel.topAnchor.constraint(equalTo: headerView.topAnchor),
+                avgTimingLabel.bottomAnchor.constraint(equalTo: lineView.topAnchor, constant: -8),
+                
+                diffLabel.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -8),
+                diffLabel.topAnchor.constraint(equalTo: headerView.topAnchor),
+                diffLabel.bottomAnchor.constraint(equalTo: lineView.topAnchor, constant: -8),
+            ])
+        }
+
+        headerView.addSubview(headerLabel)
+        headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Set Auto Layout constraints
+        NSLayoutConstraint.activate([
+            headerLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 16),
+            headerLabel.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 8),
+            headerLabel.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -16),
+            lineView.heightAnchor.constraint(equalToConstant: 1), // Line thickness
+            lineView.leadingAnchor.constraint(equalTo: headerView.leadingAnchor),
+            lineView.trailingAnchor.constraint(equalTo: headerView.trailingAnchor),
+            lineView.bottomAnchor.constraint(equalTo: headerView.bottomAnchor), // Position at the bottom
+            lineView.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: 8) // Space between label and line
+        ])
+        
+        return headerView
+    }
+
+    func configureHeaderLabel(label: UILabel, text: String) {
+        label.text = text
+        label.textColor = .white
+        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
+    }
+
     @objc func submitAction() {
         print("Selected algorithms: \(selectedAlgorithms.map { algorithms[$0] })")
 
-        for index in selectedAlgorithms.sorted() {
-            let algorithm = algorithms[index]
-            do {
-                print("Running MSM in algorithm: \(algorithm)...")
-                if let benchmarkFunction = msmBenchmarkMapping[algorithm] {
-                    let benchData: BenchmarkResult = try benchmarkFunction(10000)
-                    print("Result of \(algorithm): \n \(benchData)")
+        // offload heavy computation of benchmarking in background
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+
+            var tempResults: [AlgorithmBenchmark] = []
+
+            for index in self.selectedAlgorithms.sorted() {
+                let algorithm = self.algorithms[index]
+
+                if let benchmarkFunction = self.msmBenchmarkMapping[algorithm] {
+                    do {
+                        print("Running MSM in algorithm: \(algorithm)...")
+                        let benchData: BenchmarkResult = try benchmarkFunction(10000)
+                        let algorithmBenchmark = AlgorithmBenchmark(
+                            algorithm: algorithm,
+                            avgMsmTime: benchData.avgProcessingTime,
+                            diffWithBaseline: 0.0 // Consider calculating this in background too
+                        )
+                        tempResults.append(algorithmBenchmark)
+                        print("Result of \(algorithmBenchmark.algorithm): \(algorithmBenchmark.avgMsmTime) ms (diff: \(algorithmBenchmark.diffWithBaseline) ms)")
+                    } catch {
+                        print("Error running benchmark: \(error)")
+                    }
+                } else {
+                    print("No benchmark function found for \(algorithm)")
+                    tempResults.append(AlgorithmBenchmark(algorithm: algorithm, avgMsmTime: Double.nan, diffWithBaseline: Double.nan))
                 }
-            } catch {
-                    print("Error running benchmark: \(error)")
+            }
+
+            DispatchQueue.main.async {
+                self.benchmarkResults = tempResults
+                self.resultsTableView.reloadData()
             }
         }
+    }
+
+}
+
+class BenchmarkResultCell: UITableViewCell {
+    let nameLabel = UILabel()
+    let avgTimeLabel = UILabel()
+    let diffLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+        self.backgroundColor = .black
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupViews() {
+        // Add labels to the cell's contentView
+        [nameLabel, avgTimeLabel, diffLabel].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview($0)
+            $0.textColor = .white
+        }
+        
+        // Set Auto Layout constraints
+        NSLayoutConstraint.activate([
+            nameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
+            nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8), // Add top constraint
+            nameLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8), // Add bottom constraint to ensure vertical spacing is defined
+            
+            avgTimeLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            avgTimeLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            
+            diffLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
+            diffLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+        ])
     }
 }

--- a/mopro-ios/MoproKit/Example/MoproKit/MSMBenchmarkViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/MSMBenchmarkViewController.swift
@@ -1,0 +1,275 @@
+//
+//  MSMBenchmarkViewController.swift
+//  MoproKit_Example
+//
+//  Created by Fuchuan Chung on 2024/2/6.
+//  Copyright © 2024 CocoaPods. All rights reserved.
+//x
+
+//import UIKit
+//import WebKit
+//import MoproKit
+
+//class MSMBenchmarkViewController: UITableViewController, WKScriptMessageHandler, WKNavigationDelegate {
+
+//    let webView = WKWebView()
+//    let moproCircom = MoproKit.MoproCircom()
+//    //var setupResult: SetupResult?
+//    var generatedProof: Data?
+//    var publicInputs: Data?
+//    let containerView = UIView()
+//    var textView = UITextView()
+//    
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//            runInitAction()
+//            setupUI()
+//            
+//            let contentController = WKUserContentController()
+//            contentController.add(self, name: "startProvingHandler")
+//            contentController.add(self, name: "messageHandler")
+//            
+//            let configuration = WKWebViewConfiguration()
+//            configuration.userContentController = contentController
+//            configuration.preferences.javaScriptEnabled = true
+//            
+//            // Assign the configuration to the WKWebView
+//            let webView = WKWebView(frame: view.bounds, configuration: configuration)
+//            webView.navigationDelegate = self
+//                
+//            view.addSubview(webView)
+//            view.addSubview(textView)
+//            
+//            guard let url = URL(string: "https://webview-anon-adhaar.vercel.app/") else { return }
+//            webView.load(URLRequest(url: url))
+//    }
+//    
+//    func setupUI() {
+//         textView.isEditable = false
+//
+//        textView.translatesAutoresizingMaskIntoConstraints = false
+//         view.addSubview(textView)
+//
+//         // Make text view visible
+//         textView.heightAnchor.constraint(equalToConstant: 200).isActive = true
+//
+//         NSLayoutConstraint.activate([
+//            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+//                    textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+//                    textView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+//         ])
+//     }
+//    
+//    
+//    
+//    @objc func runInitAction() {
+//        // Update the textView on the main thread
+//        DispatchQueue.main.async {
+//            self.textView.text += "Initializing library\n"
+//        }
+//
+//        // Execute long-running tasks in the background
+//        DispatchQueue.global(qos: .userInitiated).async {
+//            // Record start time
+//            let start = CFAbsoluteTimeGetCurrent()
+//
+//            do {
+//                try initializeMopro()
+//
+//                // Record end time and compute duration
+//                let end = CFAbsoluteTimeGetCurrent()
+//                let timeTaken = end - start
+//
+//                // Again, update the UI on the main thread
+//                DispatchQueue.main.async {
+//                    self.textView.text += "Initializing arkzkey took \(timeTaken) seconds.\n"
+//                }
+//            } catch {
+//                // Handle errors - update UI on main thread
+//                DispatchQueue.main.async {
+//                    self.textView.text += "An error occurred during initialization: \(error)\n"
+//                }
+//            }
+//        }
+//    }
+//    
+//    @objc func runProveAction(inputs: [String: [String]]) {
+//        // Logic for prove (generate_proof2)
+//        do {
+//            textView.text += "Starts proving...\n"
+//            // Record start time
+//            let start = CFAbsoluteTimeGetCurrent()
+//            
+//            // Generate Proof
+//            let generateProofResult = try generateProof2(circuitInputs: inputs)
+//            assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
+//            //assert(Data(expectedOutput) == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
+//            
+//            // Record end time and compute duration
+//            let end = CFAbsoluteTimeGetCurrent()
+//            let timeTaken = end - start
+//            
+//            // Store the generated proof and public inputs for later verification
+//            generatedProof = generateProofResult.proof
+//            publicInputs = generateProofResult.inputs
+//            
+//            print("Proof generation took \(timeTaken) seconds.\n")
+//            
+//            textView.text += "Proof generated!!! \n"
+//            textView.text += "Proof generation took \(timeTaken) seconds.\n"
+//            textView.text += "---\n"
+//            runVerifyAction()
+//        } catch let error as MoproError {
+//            print("MoproError: \(error)")
+//        } catch {
+//            print("Unexpected error: \(error)")
+//        }
+//    }
+//    
+//    override func viewDidLayoutSubviews() {
+//        super.viewDidLayoutSubviews()
+//        webView.frame = view.bounds
+//    }
+//    
+//    struct Witness {
+//        let signature: [String]
+//        let modulus: [String]
+//        let base_message: [String]
+//    }
+//    
+//    // Implement WKScriptMessageHandler method
+//        func provingContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+//            if message.name == "messageHandler" {
+//                // Handle messages for "messageHandler"
+//                print("Received message from JavaScript:", message.body)
+//            }
+//        }
+//
+//    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+//        if message.name == "startProvingHandler", let data = message.body as? [String: Any] {
+//            // Check for the "witness" key in the received data
+//            if let witnessData = data["witness"] as? [String: [String]] {
+//                if let signature = witnessData["signature"],
+//                   let modulus = witnessData["modulus"],
+//                   let baseMessage = witnessData["base_message"] {
+//                    
+//                    let inputs: [String: [String]] = [
+//                        "signature": signature,
+//                        "modulus": modulus,
+//                        "base_message": baseMessage
+//                    ]
+//                    
+//                    // Call your Swift function with the received witness data
+//                    runProveAction(inputs: inputs)
+//                }
+//            } else if let error = data["error"] as? String {
+//                // Handle error data
+//                print("Received error value from JavaScript:", error)
+//            } else {
+//                print("No valid data keys found in the message data.")
+//            }
+//        }
+//    }
+//    
+//    @objc func runVerifyAction() {
+//        // Logic for verify
+//        guard let proof = generatedProof,
+//            let publicInputs = publicInputs else {
+//            print("Proof has not been generated yet.")
+//            return
+//        }
+//        do {
+//            // Verify Proof
+//            let isValid = try verifyProof2(proof: proof, publicInput: publicInputs)
+//            assert(isValid, "Proof verification should succeed")
+//
+//            textView.text += "Proof verification succeeded.\n"
+//        } catch let error as MoproError {
+//            print("MoproError: \(error)")
+//        } catch {
+//            print("Unexpected error: \(error)")
+//        }
+//    }
+//}
+
+
+import UIKit
+
+class MSMBenchmarkViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+    
+    var tableView: UITableView!
+    var submitButton: UIButton!
+    let items = ["Option 1", "Option 2", "Option 3"]
+    var selectedItems: Set<Int> = [] // Set to keep track of selected items
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTableView()
+        setupBenchmarkButton()
+    }
+    
+    func setupTableView() {
+        tableView = UITableView(frame: view.bounds)
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.allowsMultipleSelection = true // Enable multiple selection
+        view.addSubview(tableView)
+    }
+    
+    // UITableViewDataSource methods
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return items.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = items[indexPath.row]
+        
+        // Configure the cell for selected state
+        if selectedItems.contains(indexPath.row) {
+            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+        }
+        
+        return cell
+    }
+    
+    // UITableViewDelegate methods
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        selectedItems.insert(indexPath.row)
+        if let cell = tableView.cellForRow(at: indexPath) {
+            cell.accessoryType = .checkmark
+        }
+        print("Selected: \(items[indexPath.row])")
+    }
+    
+    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        selectedItems.remove(indexPath.row)
+        if let cell = tableView.cellForRow(at: indexPath) {
+            cell.accessoryType = .none
+        }
+        print("Deselected: \(items[indexPath.row])")
+    }
+    
+    func setupBenchmarkButton() {
+        submitButton = UIButton(type: .system)
+        submitButton.frame = CGRect(x: 20, y: view.bounds.height - 80, width: view.bounds.width - 60, height: 50)
+        submitButton.setTitle("Benchmark", for: .normal)
+        submitButton.addTarget(self, action: #selector(submitAction), for: .touchUpInside)
+        submitButton.backgroundColor = .systemBlue
+        submitButton.setTitleColor(.white, for: .normal)
+        submitButton.layer.cornerRadius = 10
+        view.addSubview(submitButton)
+    }
+    
+    @objc func submitAction() {
+        // Action for the submit button
+        print("Selected Items: \(selectedItems.map { items[$0] })")
+        // Here you can add further actions, like navigating to another view controller
+    }
+}
+
+// Don't forget to set this view controller as the root view controller in your AppDelegate or SceneDelegate

--- a/mopro-ios/MoproKit/Example/MoproKit/MSMBenchmarkViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/MSMBenchmarkViewController.swift
@@ -4,204 +4,33 @@
 //
 //  Created by Fuchuan Chung on 2024/2/6.
 //  Copyright © 2024 CocoaPods. All rights reserved.
-//x
-
-//import UIKit
-//import WebKit
-//import MoproKit
-
-//class MSMBenchmarkViewController: UITableViewController, WKScriptMessageHandler, WKNavigationDelegate {
-
-//    let webView = WKWebView()
-//    let moproCircom = MoproKit.MoproCircom()
-//    //var setupResult: SetupResult?
-//    var generatedProof: Data?
-//    var publicInputs: Data?
-//    let containerView = UIView()
-//    var textView = UITextView()
-//    
-//    override func viewDidLoad() {
-//        super.viewDidLoad()
-//            runInitAction()
-//            setupUI()
-//            
-//            let contentController = WKUserContentController()
-//            contentController.add(self, name: "startProvingHandler")
-//            contentController.add(self, name: "messageHandler")
-//            
-//            let configuration = WKWebViewConfiguration()
-//            configuration.userContentController = contentController
-//            configuration.preferences.javaScriptEnabled = true
-//            
-//            // Assign the configuration to the WKWebView
-//            let webView = WKWebView(frame: view.bounds, configuration: configuration)
-//            webView.navigationDelegate = self
-//                
-//            view.addSubview(webView)
-//            view.addSubview(textView)
-//            
-//            guard let url = URL(string: "https://webview-anon-adhaar.vercel.app/") else { return }
-//            webView.load(URLRequest(url: url))
-//    }
-//    
-//    func setupUI() {
-//         textView.isEditable = false
 //
-//        textView.translatesAutoresizingMaskIntoConstraints = false
-//         view.addSubview(textView)
-//
-//         // Make text view visible
-//         textView.heightAnchor.constraint(equalToConstant: 200).isActive = true
-//
-//         NSLayoutConstraint.activate([
-//            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-//                    textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-//                    textView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
-//         ])
-//     }
-//    
-//    
-//    
-//    @objc func runInitAction() {
-//        // Update the textView on the main thread
-//        DispatchQueue.main.async {
-//            self.textView.text += "Initializing library\n"
-//        }
-//
-//        // Execute long-running tasks in the background
-//        DispatchQueue.global(qos: .userInitiated).async {
-//            // Record start time
-//            let start = CFAbsoluteTimeGetCurrent()
-//
-//            do {
-//                try initializeMopro()
-//
-//                // Record end time and compute duration
-//                let end = CFAbsoluteTimeGetCurrent()
-//                let timeTaken = end - start
-//
-//                // Again, update the UI on the main thread
-//                DispatchQueue.main.async {
-//                    self.textView.text += "Initializing arkzkey took \(timeTaken) seconds.\n"
-//                }
-//            } catch {
-//                // Handle errors - update UI on main thread
-//                DispatchQueue.main.async {
-//                    self.textView.text += "An error occurred during initialization: \(error)\n"
-//                }
-//            }
-//        }
-//    }
-//    
-//    @objc func runProveAction(inputs: [String: [String]]) {
-//        // Logic for prove (generate_proof2)
-//        do {
-//            textView.text += "Starts proving...\n"
-//            // Record start time
-//            let start = CFAbsoluteTimeGetCurrent()
-//            
-//            // Generate Proof
-//            let generateProofResult = try generateProof2(circuitInputs: inputs)
-//            assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
-//            //assert(Data(expectedOutput) == generateProofResult.inputs, "Circuit outputs mismatch the expected outputs")
-//            
-//            // Record end time and compute duration
-//            let end = CFAbsoluteTimeGetCurrent()
-//            let timeTaken = end - start
-//            
-//            // Store the generated proof and public inputs for later verification
-//            generatedProof = generateProofResult.proof
-//            publicInputs = generateProofResult.inputs
-//            
-//            print("Proof generation took \(timeTaken) seconds.\n")
-//            
-//            textView.text += "Proof generated!!! \n"
-//            textView.text += "Proof generation took \(timeTaken) seconds.\n"
-//            textView.text += "---\n"
-//            runVerifyAction()
-//        } catch let error as MoproError {
-//            print("MoproError: \(error)")
-//        } catch {
-//            print("Unexpected error: \(error)")
-//        }
-//    }
-//    
-//    override func viewDidLayoutSubviews() {
-//        super.viewDidLayoutSubviews()
-//        webView.frame = view.bounds
-//    }
-//    
-//    struct Witness {
-//        let signature: [String]
-//        let modulus: [String]
-//        let base_message: [String]
-//    }
-//    
-//    // Implement WKScriptMessageHandler method
-//        func provingContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-//            if message.name == "messageHandler" {
-//                // Handle messages for "messageHandler"
-//                print("Received message from JavaScript:", message.body)
-//            }
-//        }
-//
-//    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-//        if message.name == "startProvingHandler", let data = message.body as? [String: Any] {
-//            // Check for the "witness" key in the received data
-//            if let witnessData = data["witness"] as? [String: [String]] {
-//                if let signature = witnessData["signature"],
-//                   let modulus = witnessData["modulus"],
-//                   let baseMessage = witnessData["base_message"] {
-//                    
-//                    let inputs: [String: [String]] = [
-//                        "signature": signature,
-//                        "modulus": modulus,
-//                        "base_message": baseMessage
-//                    ]
-//                    
-//                    // Call your Swift function with the received witness data
-//                    runProveAction(inputs: inputs)
-//                }
-//            } else if let error = data["error"] as? String {
-//                // Handle error data
-//                print("Received error value from JavaScript:", error)
-//            } else {
-//                print("No valid data keys found in the message data.")
-//            }
-//        }
-//    }
-//    
-//    @objc func runVerifyAction() {
-//        // Logic for verify
-//        guard let proof = generatedProof,
-//            let publicInputs = publicInputs else {
-//            print("Proof has not been generated yet.")
-//            return
-//        }
-//        do {
-//            // Verify Proof
-//            let isValid = try verifyProof2(proof: proof, publicInput: publicInputs)
-//            assert(isValid, "Proof verification should succeed")
-//
-//            textView.text += "Proof verification succeeded.\n"
-//        } catch let error as MoproError {
-//            print("MoproError: \(error)")
-//        } catch {
-//            print("Unexpected error: \(error)")
-//        }
-//    }
-//}
-
 
 import UIKit
+import MoproKit
 
 class MSMBenchmarkViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
     var tableView: UITableView!
     var submitButton: UIButton!
-    let items = ["Option 1", "Option 2", "Option 3"]
-    var selectedItems: Set<Int> = [] // Set to keep track of selected items
     
+    let algorithms = ["1. Arkwork MSM", "2. ", "3. "]
+    var selectedAlgorithms: Set<Int> = []
+    
+    // for benchmark results
+    var resultsView: UIView!
+    var resultsTableView: UITableView!
+    var benchmarkResults: [BenchmarkResult] = []
+    
+    typealias BenchmarkClosure = () throws -> BenchmarkResult
+    
+    let msmBenchmarkMapping: [String: (UInt32?) throws -> BenchmarkResult] = [
+        // update the mapping with function in the future
+        "1. Arkwork MSM": runMsmBenchmark,
+//        "2. ": msmFunction2,
+//        "3. ": msmFunction3,
+    ]
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTableView()
@@ -217,47 +46,10 @@ class MSMBenchmarkViewController: UIViewController, UITableViewDelegate, UITable
         view.addSubview(tableView)
     }
     
-    // UITableViewDataSource methods
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return items.count
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        cell.textLabel?.text = items[indexPath.row]
-        
-        // Configure the cell for selected state
-        if selectedItems.contains(indexPath.row) {
-            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
-            cell.accessoryType = .checkmark
-        } else {
-            cell.accessoryType = .none
-        }
-        
-        return cell
-    }
-    
-    // UITableViewDelegate methods
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        selectedItems.insert(indexPath.row)
-        if let cell = tableView.cellForRow(at: indexPath) {
-            cell.accessoryType = .checkmark
-        }
-        print("Selected: \(items[indexPath.row])")
-    }
-    
-    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-        selectedItems.remove(indexPath.row)
-        if let cell = tableView.cellForRow(at: indexPath) {
-            cell.accessoryType = .none
-        }
-        print("Deselected: \(items[indexPath.row])")
-    }
-    
     func setupBenchmarkButton() {
         submitButton = UIButton(type: .system)
         submitButton.frame = CGRect(x: 20, y: view.bounds.height - 80, width: view.bounds.width - 60, height: 50)
-        submitButton.setTitle("Benchmark", for: .normal)
+        submitButton.setTitle("Generating Benchmarks", for: .normal)
         submitButton.addTarget(self, action: #selector(submitAction), for: .touchUpInside)
         submitButton.backgroundColor = .systemBlue
         submitButton.setTitleColor(.white, for: .normal)
@@ -265,11 +57,56 @@ class MSMBenchmarkViewController: UIViewController, UITableViewDelegate, UITable
         view.addSubview(submitButton)
     }
     
+    // UITableViewDataSource methods
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return algorithms.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = algorithms[indexPath.row]
+        
+        if selectedAlgorithms.contains(indexPath.row) {
+            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+        }
+        return cell
+    }
+    
+    // UITableViewDelegate methods
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        selectedAlgorithms.insert(indexPath.row)
+        if let cell = tableView.cellForRow(at: indexPath) {
+            cell.accessoryType = .checkmark
+        }
+        print("Selected: \(algorithms[indexPath.row])")
+    }
+    
+    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        selectedAlgorithms.remove(indexPath.row)
+        if let cell = tableView.cellForRow(at: indexPath) {
+            cell.accessoryType = .none
+        }
+        print("Deselected: \(algorithms[indexPath.row])")
+    }
+    
     @objc func submitAction() {
-        // Action for the submit button
-        print("Selected Items: \(selectedItems.map { items[$0] })")
-        // Here you can add further actions, like navigating to another view controller
+        print("Selected algorithms: \(selectedAlgorithms.map { algorithms[$0] })")
+
+        for index in selectedAlgorithms.sorted() {
+            let algorithm = algorithms[index]
+            do {
+                print("Running MSM in algorithm: \(algorithm)...")
+                if let benchmarkFunction = msmBenchmarkMapping[algorithm] {
+                    let benchData: BenchmarkResult = try benchmarkFunction(10000)
+                    print("Result of \(algorithm): \n \(benchData)")
+                }
+            } catch {
+                    print("Error running benchmark: \(error)")
+            }
+        }
     }
 }
-
-// Don't forget to set this view controller as the root view controller in your AppDelegate or SceneDelegate

--- a/mopro-ios/MoproKit/Example/MoproKit/ViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/ViewController.swift
@@ -19,6 +19,7 @@ class ViewController: UIViewController {
     let aadhaarButton = UIButton(type: .system)
     let aadhaarNewButton = UIButton(type: .system)
     let complexNewButton = UIButton(type: .system)
+    let msmbenchmarkButton = UIButton(type: .system)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -55,6 +56,8 @@ class ViewController: UIViewController {
         complexNewButton.setTitle("Complex Test", for: .normal)
         complexNewButton.addTarget(self, action: #selector(openComplex), for: .touchUpInside)
 
+        msmbenchmarkButton.setTitle("MSM Benchmark", for: .normal)
+        msmbenchmarkButton.addTarget(self, action: #selector(openMSMBenchmark), for: .touchUpInside)
 
        keccakSetupButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
        keccakZkeyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
@@ -64,7 +67,7 @@ class ViewController: UIViewController {
 //        navigationController?.navigationBar.prefersLargeTitles = true
 
 
-        let stackView = UIStackView(arrangedSubviews: [keccakSetupButton, keccakZkeyButton, rsaButton, aadhaarButton, aadhaarNewButton, complexNewButton])
+        let stackView = UIStackView(arrangedSubviews: [keccakSetupButton, keccakZkeyButton, rsaButton, aadhaarButton, aadhaarNewButton, complexNewButton, msmbenchmarkButton])
         stackView.axis = .vertical
         stackView.spacing = 20
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -105,6 +108,11 @@ class ViewController: UIViewController {
         let complexVCNew = ComplexZkeyViewController()
         navigationController?.pushViewController(complexVCNew, animated: true)
     }
+
+    @objc func openMSMBenchmark() {
+         let msmbenchmarkVC = MSMBenchmarkViewController()
+         navigationController?.pushViewController(msmbenchmarkVC, animated: true)
+    }
 }
 
 //        // Make buttons bigger
@@ -116,3 +124,5 @@ class ViewController: UIViewController {
 //            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
 //            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20)
 //        ])
+
+

--- a/mopro-ios/README.md
+++ b/mopro-ios/README.md
@@ -49,3 +49,13 @@ There are two ways to run tests for the example app:
     ```sh
     xcodebuild -showdestinations -workspace MoproKit.xcworkspace -scheme MoproKit-Example
     ```
+
+## Run MSM Benchmark
+
+1. `cd mopro-ffi/` and convert `default=[]` into `default=["gpu-benchmarks"]` to enable `gpu-benchmarks` feature flag
+2. run `make` to build the mopro-ffi library
+3. `cd mopro/` and run `./scripts/build_ios.sh config-example.toml` to build IOS app and link
+   * remember to alter the `device_type` in `config-example.toml`
+   * `simulator`: running on the simulator (default)
+   * `device`: running on a real IOS device
+4. Open `MoproKit/Example/MoproKit.xcworkspace` in Xcode and `cmd + R` for building


### PR DESCRIPTION
# Integrating MSM benchmark on IOS 

> we are aiming to integrate the previous work into IOS Example project


## TODO Log
### iOS
- [x] Design the way to illustrate the benchmark of this
    - [x] A swift file that maps all algorithm from uniffi to swift. <u>Make it the only file we need to change if added a new algorithm.</u>
    - [x] A swift file for UI
        - [x] A component to show the integrated algorithm
        - [x] Rendering the mapped algorithm and wrapped it into components
        - [x] A button component for "Generating Benchmarks"
    - [x] A swift file for report generating logic
        - [x] show a table for (`num_msm`)
            | Algorithm   | Avg Timing | Compare to baseline <br>(arkwork-msm)</br> |
            | ----------- | --------------- |:------------------------------------------:|
            | arkworks-msm | in ms           |                     -                      |
            | Algo. A     | in ms           |                    in %                    |
            | Algo. B     | in ms           |                    in %                    |

        - [x] [Backlog] show a figure 

## Link 

- [report](https://hackmd.io/OGYdUUsoQzump7uLB5YqKg)