### PR TITLE
initialize mopro with arkzkey and wasm

### DIFF
--- a/mopro-core/examples/circom.rs
+++ b/mopro-core/examples/circom.rs
@@ -4,13 +4,13 @@ use std::collections::HashMap;
 
 fn main() {
     let wasm_path = "./examples/circom/multiplier2/target/multiplier2_js/multiplier2.wasm";
-    let r1cs_path = "./examples/circom/multiplier2/target/multiplier2.r1cs";
+    let arkzkey_path = "./examples/circom/multiplier2/target/multiplier2_final.arkzkey";
 
     // Instantiate CircomState
     let mut circom_state = CircomState::new();
 
     // Setup
-    let setup_res = circom_state.setup(wasm_path, r1cs_path);
+    let setup_res = circom_state.initialize(arkzkey_path, wasm_path);
     assert!(setup_res.is_ok());
 
     let _serialized_pk = setup_res.unwrap();

--- a/mopro-ffi/src/mopro.udl
+++ b/mopro-ffi/src/mopro.udl
@@ -21,10 +21,6 @@ namespace mopro {
   sequence<string> to_ethereum_inputs(bytes inputs);
 };
 
-dictionary SetupResult {
-  bytes provingKey;
-};
-
 dictionary GenerateProofResult {
   bytes proof;
   bytes inputs;
@@ -62,7 +58,7 @@ interface MoproCircom {
   constructor();
 
   [Throws=MoproError]
-  SetupResult setup(string wasm_path, string r1cs_path);
+  void initialize(string arkzkey_path, string wasm_path);
 
   [Throws=MoproError]
   GenerateProofResult generate_proof(record<string, sequence<string>> circuit_inputs);

--- a/mopro-ffi/tests/bindings/test_mopro.kts
+++ b/mopro-ffi/tests/bindings/test_mopro.kts
@@ -1,13 +1,12 @@
 import uniffi.mopro.*
 
 var wasmPath = "../mopro-core/examples/circom/multiplier2/target/multiplier2_js/multiplier2.wasm"
-var r1csPath = "../mopro-core/examples/circom/multiplier2/target/multiplier2.r1cs"
+var arkzkeyPath = "../mopro-core/examples/circom/multiplier2/target/multiplier2_final.arkzkey"
 
 try {
     // Setup
     var moproCircom = MoproCircom()
-    var setupResult = moproCircom.setup(wasmPath, r1csPath)
-    assert(setupResult.provingKey.size > 0) { "Proving key should not be empty" }
+    moproCircom.initialize(arkzkeyPath, wasmPath)
 
     // Prepare inputs
     val inputs = mutableMapOf<String, List<String>>()

--- a/mopro-ffi/tests/bindings/test_mopro.swift
+++ b/mopro-ffi/tests/bindings/test_mopro.swift
@@ -4,7 +4,7 @@ import Foundation
 let moproCircom = MoproCircom()
 
 let wasmPath = "./../../../../mopro-core/examples/circom/multiplier2/target/multiplier2_js/multiplier2.wasm"
-let r1csPath = "./../../../../mopro-core/examples/circom/multiplier2/target/multiplier2.r1cs"
+let arkzkeyPath = "./../../../../mopro-core/examples/circom/multiplier2/target/multiplier2_final.arkzkey"
 
 func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
     var bytesArray: [UInt8] = []
@@ -33,8 +33,7 @@ func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
 
 do {
     // Setup
-    let setupResult = try moproCircom.setup(wasmPath: wasmPath, r1csPath: r1csPath)
-    assert(!setupResult.provingKey.isEmpty, "Proving key should not be empty")
+    try moproCircom.initialize(arkzkeyPath: arkzkeyPath ,wasmPath: wasmPath)
 
     // Prepare inputs
     var inputs = [String: [String]]()

--- a/mopro-ffi/tests/bindings/test_mopro_keccak.kts
+++ b/mopro-ffi/tests/bindings/test_mopro_keccak.kts
@@ -2,13 +2,12 @@ import uniffi.mopro.*
 
 var wasmPath =
         "../mopro-core/examples/circom/keccak256/target/keccak256_256_test_js/keccak256_256_test.wasm"
-var r1csPath = "../mopro-core/examples/circom/keccak256/target/keccak256_256_test.r1cs"
+var arkzkeyPath = "../mopro-core/examples/circom/keccak256/target/keccak256_256_test_final.arkzkey"
 
 try {
     var moproCircom = MoproCircom()
-    var setupResult = moproCircom.setup(wasmPath, r1csPath)
-    assert(setupResult.provingKey.size > 0) { "Proving key should not be empty" }
-
+    moproCircom.initialize(arkzkeyPath, wasmPath)
+    
     val inputs = mutableMapOf<String, List<String>>()
     inputs["in"] =
             listOf(

--- a/mopro-ffi/tests/bindings/test_mopro_keccak.swift
+++ b/mopro-ffi/tests/bindings/test_mopro_keccak.swift
@@ -4,7 +4,7 @@ import Foundation
 let moproCircom = MoproCircom()
 
 let wasmPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_js/keccak256_256_test.wasm"
-let r1csPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test.r1cs"
+let arkzkeyPath = "./../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_final.arkzkey"
 
 // Helper function to convert bytes to bits
 func bytesToBits(bytes: [UInt8]) -> [String] {
@@ -45,8 +45,7 @@ func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
 
 do {
     // Setup
-    let setupResult = try moproCircom.setup(wasmPath: wasmPath, r1csPath: r1csPath)
-    assert(!setupResult.provingKey.isEmpty, "Proving key should not be empty")
+    try moproCircom.initialize(arkzkeyPath: arkzkeyPath, wasmPath: wasmPath)
 
     // Prepare inputs
     let inputVec: [UInt8] = [

--- a/mopro-ffi/tests/bindings/test_mopro_keccak2.swift
+++ b/mopro-ffi/tests/bindings/test_mopro_keccak2.swift
@@ -46,9 +46,6 @@ func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
 }
 
 do {
-  // // Setup
-  // let setupResult = try moproCircom.setup(wasmPath: wasmPath, r1csPath: r1csPath)
-  // assert(!setupResult.provingKey.isEmpty, "Proving key should not be empty")
 
   // Prepare inputs
   let inputVec: [UInt8] = [

--- a/mopro-ffi/tests/bindings/test_mopro_rsa.kts
+++ b/mopro-ffi/tests/bindings/test_mopro_rsa.kts
@@ -1,12 +1,11 @@
 import uniffi.mopro.*;
 
 var wasmPath = "../mopro-core/examples/circom/rsa/target/main_js/main.wasm"
-var r1csPath = "../mopro-core/examples/circom/rsa/target/main.r1cs"
+var arkzkeyPath = "../mopro-core/examples/circom/rsa/target/main_final.arkzkey"
 
 try {
     var moproCircom = MoproCircom()
-    var setupResult = moproCircom.setup(wasmPath, r1csPath)
-    assert(setupResult.provingKey.size > 0) { "Proving key should not be empty"}
+    moproCircom.initialize(arkzkeyPath, wasmPath)
 
     val inputs = mutableMapOf<String, List<String>>()
     inputs["signature"] = listOf("3582320600048169363",

--- a/mopro-ffi/tests/bindings/test_mopro_rsa.swift
+++ b/mopro-ffi/tests/bindings/test_mopro_rsa.swift
@@ -4,7 +4,7 @@ import Foundation
 let moproCircom = MoproCircom()
 
 let wasmPath = "./../../../../mopro-core/examples/circom/rsa/target/main_js/main.wasm"
-let r1csPath = "./../../../../mopro-core/examples/circom/rsa/target/main.r1cs"
+let arkzkeyPath = "./../../../../mopro-core/examples/circom/rsa/target/main_final.arkzkey"
 
 // Helper function to convert bytes to bits
 func bytesToBits(bytes: [UInt8]) -> [String] {
@@ -45,8 +45,7 @@ func serializeOutputs(_ stringArray: [String]) -> [UInt8] {
 
 do {
     // Setup
-    let setupResult = try moproCircom.setup(wasmPath: wasmPath, r1csPath: r1csPath)
-    assert(!setupResult.provingKey.isEmpty, "Proving key should not be empty")
+    try moproCircom.initialize(arkzkeyPath: arkzkeyPath ,wasmPath: wasmPath)
 
     // Prepare inputs
     let signature: [String] = [

--- a/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
+++ b/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		2A5149C82B87616600B57A44 /* multiplier2_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C62B87616600B57A44 /* multiplier2_final.arkzkey */; };
 		2A5149CA2B87618000B57A44 /* main_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C92B87618000B57A44 /* main_final.arkzkey */; };
 		2A5149CB2B87618000B57A44 /* main_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C92B87618000B57A44 /* main_final.arkzkey */; };
+		2A5149CD2B8766DA00B57A44 /* FileDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5149CC2B8766DA00B57A44 /* FileDownloader.swift */; };
+		2A5149CE2B8766DA00B57A44 /* FileDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5149CC2B8766DA00B57A44 /* FileDownloader.swift */; };
 		2A6E5BAF2AF499460052A601 /* CircomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6E5BAE2AF499460052A601 /* CircomTests.swift */; };
 		4384FD09A96F702A375841EE /* Pods_MoproKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78B0F9CBE5DD22576996A993 /* Pods_MoproKit_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -56,6 +58,7 @@
 		2A5149C32B87615900B57A44 /* keccak256_256_test_final.arkzkey */ = {isa = PBXFileReference; lastKnownFileType = file; name = keccak256_256_test_final.arkzkey; path = "../../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_final.arkzkey"; sourceTree = "<group>"; };
 		2A5149C62B87616600B57A44 /* multiplier2_final.arkzkey */ = {isa = PBXFileReference; lastKnownFileType = file; name = multiplier2_final.arkzkey; path = "../../../../../mopro-core/examples/circom/multiplier2/target/multiplier2_final.arkzkey"; sourceTree = "<group>"; };
 		2A5149C92B87618000B57A44 /* main_final.arkzkey */ = {isa = PBXFileReference; lastKnownFileType = file; name = main_final.arkzkey; path = "../../../../../mopro-core/examples/circom/rsa/target/main_final.arkzkey"; sourceTree = "<group>"; };
+		2A5149CC2B8766DA00B57A44 /* FileDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDownloader.swift; sourceTree = "<group>"; };
 		2A6E5BAE2AF499460052A601 /* CircomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomTests.swift; sourceTree = "<group>"; };
 		47F8ADB0AC4168C6E874818D /* MoproKit.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = MoproKit.podspec; path = ../MoproKit.podspec; sourceTree = "<group>"; };
 		5DAF212A114DFA0C9F4282B2 /* Pods-MoproKit_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoproKit_Tests.debug.xcconfig"; path = "Target Support Files/Pods-MoproKit_Tests/Pods-MoproKit_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -143,6 +146,7 @@
 				CEB804572AFF81BF0063F091 /* RSAViewController.swift */,
 				E6E6F42D2B5860F7002F5F18 /* AnonAadhaarViewControllerNew.swift */,
 				E69338632AFFDB1A00B80312 /* AnonAadhaarViewController.swift */,
+				2A5149CC2B8766DA00B57A44 /* FileDownloader.swift */,
 				CEB804552AFF81AF0063F091 /* KeccakZkeyViewController.swift */,
 				E6D848582B766C8C00DBAF30 /* ComplexZkeyViewController.swift */,
 				CEB8044F2AFF81960063F091 /* KeccakSetupViewController.swift */,
@@ -437,6 +441,7 @@
 				CEB804502AFF81960063F091 /* KeccakSetupViewController.swift in Sources */,
 				E6D848592B766C8C00DBAF30 /* ComplexZkeyViewController.swift in Sources */,
 				E6E6F42E2B5860F7002F5F18 /* AnonAadhaarViewControllerNew.swift in Sources */,
+				2A5149CD2B8766DA00B57A44 /* FileDownloader.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 				E69338642AFFDB1A00B80312 /* AnonAadhaarViewController.swift in Sources */,
 			);
@@ -446,6 +451,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2A5149CE2B8766DA00B57A44 /* FileDownloader.swift in Sources */,
 				2A6E5BAF2AF499460052A601 /* CircomTests.swift in Sources */,
 				2A418AB02AF4B1200004B747 /* CircomUITests.swift in Sources */,
 			);

--- a/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
+++ b/mopro-ios/MoproKit/Example/MoproKit.xcodeproj/project.pbxproj
@@ -8,6 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		2A418AB02AF4B1200004B747 /* CircomUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A418AAF2AF4B1200004B747 /* CircomUITests.swift */; };
+		2A5149C42B87615900B57A44 /* keccak256_256_test_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C32B87615900B57A44 /* keccak256_256_test_final.arkzkey */; };
+		2A5149C52B87615900B57A44 /* keccak256_256_test_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C32B87615900B57A44 /* keccak256_256_test_final.arkzkey */; };
+		2A5149C72B87616600B57A44 /* multiplier2_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C62B87616600B57A44 /* multiplier2_final.arkzkey */; };
+		2A5149C82B87616600B57A44 /* multiplier2_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C62B87616600B57A44 /* multiplier2_final.arkzkey */; };
+		2A5149CA2B87618000B57A44 /* main_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C92B87618000B57A44 /* main_final.arkzkey */; };
+		2A5149CB2B87618000B57A44 /* main_final.arkzkey in Resources */ = {isa = PBXBuildFile; fileRef = 2A5149C92B87618000B57A44 /* main_final.arkzkey */; };
 		2A6E5BAF2AF499460052A601 /* CircomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6E5BAE2AF499460052A601 /* CircomTests.swift */; };
 		4384FD09A96F702A375841EE /* Pods_MoproKit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78B0F9CBE5DD22576996A993 /* Pods_MoproKit_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -47,6 +53,9 @@
 /* Begin PBXFileReference section */
 		1E5E014D70B48C9A59F14658 /* Pods-MoproKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoproKit_Example.release.xcconfig"; path = "Target Support Files/Pods-MoproKit_Example/Pods-MoproKit_Example.release.xcconfig"; sourceTree = "<group>"; };
 		2A418AAF2AF4B1200004B747 /* CircomUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomUITests.swift; sourceTree = "<group>"; };
+		2A5149C32B87615900B57A44 /* keccak256_256_test_final.arkzkey */ = {isa = PBXFileReference; lastKnownFileType = file; name = keccak256_256_test_final.arkzkey; path = "../../../../../mopro-core/examples/circom/keccak256/target/keccak256_256_test_final.arkzkey"; sourceTree = "<group>"; };
+		2A5149C62B87616600B57A44 /* multiplier2_final.arkzkey */ = {isa = PBXFileReference; lastKnownFileType = file; name = multiplier2_final.arkzkey; path = "../../../../../mopro-core/examples/circom/multiplier2/target/multiplier2_final.arkzkey"; sourceTree = "<group>"; };
+		2A5149C92B87618000B57A44 /* main_final.arkzkey */ = {isa = PBXFileReference; lastKnownFileType = file; name = main_final.arkzkey; path = "../../../../../mopro-core/examples/circom/rsa/target/main_final.arkzkey"; sourceTree = "<group>"; };
 		2A6E5BAE2AF499460052A601 /* CircomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircomTests.swift; sourceTree = "<group>"; };
 		47F8ADB0AC4168C6E874818D /* MoproKit.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = MoproKit.podspec; path = ../MoproKit.podspec; sourceTree = "<group>"; };
 		5DAF212A114DFA0C9F4282B2 /* Pods-MoproKit_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoproKit_Tests.debug.xcconfig"; path = "Target Support Files/Pods-MoproKit_Tests/Pods-MoproKit_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -190,6 +199,9 @@
 			children = (
 				CE2C1B8B2AFFCC5E002AF8BC /* main.wasm */,
 				CE5A5C082AD43A860074539D /* keccak256_256_test.r1cs */,
+				2A5149C62B87616600B57A44 /* multiplier2_final.arkzkey */,
+				2A5149C32B87615900B57A44 /* keccak256_256_test_final.arkzkey */,
+				2A5149C92B87618000B57A44 /* main_final.arkzkey */,
 				CE5A5C052AD43A790074539D /* keccak256_256_test.wasm */,
 				CEA2D12E2AB96A7A00F292D2 /* multiplier2.wasm */,
 				CEA2D1312AB96AB500F292D2 /* multiplier2.r1cs */,
@@ -300,9 +312,12 @@
 			files = (
 				CEA2D1322AB96AB500F292D2 /* multiplier2.r1cs in Resources */,
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
+				2A5149C42B87615900B57A44 /* keccak256_256_test_final.arkzkey in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
+				2A5149CA2B87618000B57A44 /* main_final.arkzkey in Resources */,
 				CE5A5C062AD43A790074539D /* keccak256_256_test.wasm in Resources */,
 				CE2C1B8C2AFFCC5E002AF8BC /* main.wasm in Resources */,
+				2A5149C72B87616600B57A44 /* multiplier2_final.arkzkey in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 				CEA2D12F2AB96A7A00F292D2 /* multiplier2.wasm in Resources */,
 				CE5A5C092AD43A860074539D /* keccak256_256_test.r1cs in Resources */,
@@ -315,9 +330,12 @@
 			files = (
 				CE5A5C0A2AD43A860074539D /* keccak256_256_test.r1cs in Resources */,
 				CE5A5C072AD43A790074539D /* keccak256_256_test.wasm in Resources */,
+				2A5149C52B87615900B57A44 /* keccak256_256_test_final.arkzkey in Resources */,
+				2A5149C82B87616600B57A44 /* multiplier2_final.arkzkey in Resources */,
 				CE2C1B8D2AFFCC5E002AF8BC /* main.wasm in Resources */,
 				CEA2D1332AB96AB500F292D2 /* multiplier2.r1cs in Resources */,
 				CEA2D1302AB96A7A00F292D2 /* multiplier2.wasm in Resources */,
+				2A5149CB2B87618000B57A44 /* main_final.arkzkey in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mopro-ios/MoproKit/Example/MoproKit/FileDownloader.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/FileDownloader.swift
@@ -1,0 +1,95 @@
+//
+//  FileDownloader.swift
+//  MoproKit
+//
+//  Copyright © 2024 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+class FileDownloader {
+
+    static func loadFileSync(url: URL, completion: @escaping (String?, Error?) -> Void)
+    {
+        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+
+        let destinationUrl = documentsUrl.appendingPathComponent(url.lastPathComponent)
+
+        if FileManager().fileExists(atPath: destinationUrl.path)
+        {
+            print("File already exists [\(destinationUrl.path)]")
+            completion(destinationUrl.path, nil)
+        }
+        else if let dataFromURL = NSData(contentsOf: url)
+        {
+            if dataFromURL.write(to: destinationUrl, atomically: true)
+            {
+                print("file saved [\(destinationUrl.path)]")
+                completion(destinationUrl.path, nil)
+            }
+            else
+            {
+                print("error saving file")
+                let error = NSError(domain:"Error saving file", code:1001, userInfo:nil)
+                completion(destinationUrl.path, error)
+            }
+        }
+        else
+        {
+            let error = NSError(domain:"Error downloading file", code:1002, userInfo:nil)
+            completion(destinationUrl.path, error)
+        }
+    }
+
+    static func loadFileAsync(url: URL, completion: @escaping (String?, Error?) -> Void)
+    {
+        let documentsUrl =  FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+
+        let destinationUrl = documentsUrl.appendingPathComponent(url.lastPathComponent)
+
+        if FileManager().fileExists(atPath: destinationUrl.path)
+        {
+            print("File already exists [\(destinationUrl.path)]")
+            completion(destinationUrl.path, nil)
+        }
+        else
+        {
+            let session = URLSession(configuration: URLSessionConfiguration.default, delegate: nil, delegateQueue: nil)
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            let task = session.dataTask(with: request, completionHandler:
+            {
+                data, response, error in
+                if error == nil
+                {
+                    if let response = response as? HTTPURLResponse
+                    {
+                        if response.statusCode == 200
+                        {
+                            if let data = data
+                            {
+                                if let _ = try? data.write(to: destinationUrl, options: Data.WritingOptions.atomic)
+                                {
+                                    completion(destinationUrl.path, error)
+                                }
+                                else
+                                {
+                                    completion(destinationUrl.path, error)
+                                }
+                            }
+                            else
+                            {
+                                completion(destinationUrl.path, error)
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    completion(destinationUrl.path, error)
+                }
+            })
+            task.resume()
+        }
+    }
+}

--- a/mopro-ios/MoproKit/Example/MoproKit/KeccakSetupViewController.swift
+++ b/mopro-ios/MoproKit/Example/MoproKit/KeccakSetupViewController.swift
@@ -6,189 +6,220 @@
 //  Copyright (c) 2023 1552237. All rights reserved.
 //
 
-import UIKit
 import MoproKit
+import UIKit
 
 class KeccakSetupViewController: UIViewController {
 
-    var setupButton = UIButton(type: .system)
-    var proveButton = UIButton(type: .system)
-    var verifyButton = UIButton(type: .system)
-    var textView = UITextView()
+  let arkzkeyUrl = URL(string: "https://mopro.vivianjeng.xyz/keccak256_256_test_final.arkzkey")
+  let wasmUrl = URL(string: "https://mopro.vivianjeng.xyz/keccak256_256_test.wasm")
 
-    let moproCircom = MoproKit.MoproCircom()
-    var generatedProof: Data?
-    var publicInputs: Data?
+  var downloadButton = UIButton(type: .system)
+  var setupButton = UIButton(type: .system)
+  var proveButton = UIButton(type: .system)
+  var verifyButton = UIButton(type: .system)
+  var textView = UITextView()
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+  let moproCircom = MoproKit.MoproCircom()
+  var generatedProof: Data?
+  var publicInputs: Data?
 
-        // Set title
-        let title = UILabel()
-        title.text = "Keccak256 (setup)"
-        title.textColor = .white
-        title.textAlignment = .center
-        navigationItem.titleView = title
-        navigationController?.navigationBar.isHidden = false
-        navigationController?.navigationBar.prefersLargeTitles = true
+  override func viewDidLoad() {
+    super.viewDidLoad()
 
-        // view.backgroundColor = .white
-        // navigationController?.navigationBar.prefersLargeTitles = true
-        // navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.black]
-        // navigationController?.navigationBar.barTintColor = UIColor.white // or any other contrasting color
-        // self.title = "Keccak256 (setup)"
+    // Set title
+    let title = UILabel()
+    title.text = "Keccak256 (setup)"
+    title.textColor = .white
+    title.textAlignment = .center
+    navigationItem.titleView = title
+    navigationController?.navigationBar.isHidden = false
+    navigationController?.navigationBar.prefersLargeTitles = true
 
-        setupUI()
+    // view.backgroundColor = .white
+    // navigationController?.navigationBar.prefersLargeTitles = true
+    // navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.black]
+    // navigationController?.navigationBar.barTintColor = UIColor.white // or any other contrasting color
+    // self.title = "Keccak256 (setup)"
+
+    setupUI()
+  }
+
+  func setupUI() {
+    downloadButton.setTitle("Download Ark Zkey", for: .normal)
+    setupButton.setTitle("Setup", for: .normal)
+    proveButton.setTitle("Prove", for: .normal)
+    verifyButton.setTitle("Verify", for: .normal)
+
+    textView.isEditable = false
+
+    //self.title = "Keccak256 (setup)"
+    //view.backgroundColor = .black
+
+    // Setup actions for buttons
+    downloadButton.addTarget(self, action: #selector(runDownloadAction), for: .touchUpInside)
+    setupButton.addTarget(self, action: #selector(runSetupAction), for: .touchUpInside)
+    proveButton.addTarget(self, action: #selector(runProveAction), for: .touchUpInside)
+    verifyButton.addTarget(self, action: #selector(runVerifyAction), for: .touchUpInside)
+
+    downloadButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+    setupButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+    proveButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+    verifyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+
+    let stackView = UIStackView(arrangedSubviews: [
+      downloadButton, setupButton, proveButton, verifyButton, textView,
+    ])
+    stackView.axis = .vertical
+    stackView.spacing = 10
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(stackView)
+
+    // Make text view visible
+    textView.heightAnchor.constraint(equalToConstant: 200).isActive = true
+
+    NSLayoutConstraint.activate([
+      stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+      stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+      stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+    ])
+  }
+
+  @objc func runDownloadAction() {
+    let arkzkeyStart = CFAbsoluteTimeGetCurrent()
+    FileDownloader.loadFileAsync(url: self.arkzkeyUrl!) { (path, error) in
+      print("Ark zkey File downloaded to : \(path!)")
+      let arkzkeyEnd = CFAbsoluteTimeGetCurrent()
+      print("Download ark key took:", arkzkeyEnd - arkzkeyStart)
     }
 
-    func setupUI() {
-        setupButton.setTitle("Setup", for: .normal)
-        proveButton.setTitle("Prove", for: .normal)
-        verifyButton.setTitle("Verify", for: .normal)
-
-       textView.isEditable = false
-
-        //self.title = "Keccak256 (setup)"
-        //view.backgroundColor = .black
-
-        // Setup actions for buttons
-        setupButton.addTarget(self, action: #selector(runSetupAction), for: .touchUpInside)
-        proveButton.addTarget(self, action: #selector(runProveAction), for: .touchUpInside)
-        verifyButton.addTarget(self, action: #selector(runVerifyAction), for: .touchUpInside)
-
-       setupButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-       proveButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-       verifyButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-
-        let stackView = UIStackView(arrangedSubviews: [setupButton, proveButton, verifyButton, textView])
-        stackView.axis = .vertical
-        stackView.spacing = 10
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(stackView)
-
-        // Make text view visible
-        textView.heightAnchor.constraint(equalToConstant: 200).isActive = true
-
-        NSLayoutConstraint.activate([
-            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
-        ])
+    let wasmStart = CFAbsoluteTimeGetCurrent()
+    FileDownloader.loadFileAsync(url: self.wasmUrl!) { (path, error) in
+      print("wasm File downloaded to : \(path!)")
+      let wasmEnd = CFAbsoluteTimeGetCurrent()
+      print("Download wasm took:", wasmEnd - wasmStart)
     }
 
-    @objc func runSetupAction() {
-        // Logic for setup
-        if let arkzkeyPath = Bundle.main.path(forResource: "keccak256_256_test_final", ofType: "arkzkey"),
-            let wasmPath = Bundle.main.path(forResource: "keccak256_256_test", ofType: "wasm") {
+  }
 
-       // Multiplier example
-       // if let wasmPath = Bundle.main.path(forResource: "multiplier2", ofType: "wasm"),
-       //    let r1csPath = Bundle.main.path(forResource: "multiplier2", ofType: "r1cs") {
+  @objc func runSetupAction() {
+    // Logic for setup
+    if let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+      .first
+    {
 
-           do {
-            textView.text += "Initializing library\n"
-            // Record start time
-            let start = CFAbsoluteTimeGetCurrent()
+      let arkzkeyPath = documentsUrl.appendingPathComponent((arkzkeyUrl!).lastPathComponent)
+      let wasmPath = documentsUrl.appendingPathComponent((wasmUrl!).lastPathComponent)
 
-            try moproCircom.initialize(arkzkeyPath: arkzkeyPath, wasmPath: wasmPath)
-            proveButton.isEnabled = true // Enable the Prove button upon successful setup
+      // Multiplier example
+      // if let wasmPath = Bundle.main.path(forResource: "multiplier2", ofType: "wasm"),
+      //    let r1csPath = Bundle.main.path(forResource: "multiplier2", ofType: "r1cs") {
 
-            // Record end time and compute duration
-            let end = CFAbsoluteTimeGetCurrent()
-            let timeTaken = end - start
+      do {
+        textView.text += "Initializing library\n"
+        // Record start time
+        let start = CFAbsoluteTimeGetCurrent()
 
-            textView.text += "Initializing arkzkey and wasm took \(timeTaken) seconds.\n"
-           } catch let error as MoproError {
-               print("MoproError: \(error)")
-           } catch {
-               print("Unexpected error: \(error)")
-           }
-       } else {
-           print("Error getting paths for resources")
-       }
+        try moproCircom.initialize(arkzkeyPath: arkzkeyPath.path, wasmPath: wasmPath.path)
+        proveButton.isEnabled = true  // Enable the Prove button upon successful setup
+
+        // Record end time and compute duration
+        let end = CFAbsoluteTimeGetCurrent()
+        let timeTaken = end - start
+
+        textView.text += "Initializing arkzkey and wasm took \(timeTaken) seconds.\n"
+      } catch let error as MoproError {
+        print("MoproError: \(error)")
+      } catch {
+        print("Unexpected error: \(error)")
+      }
+    } else {
+      print("Error getting paths for resources")
     }
+  }
 
-    @objc func runProveAction() {
-        // Logic for prove
-        guard proveButton.isEnabled else {
-           print("Setup is not completed yet.")
-           return
-        }
-        do {
-            // Prepare inputs
-            let inputVec: [UInt8] = [
-                116, 101, 115, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0,
-            ]
-            let bits = bytesToBits(bytes: inputVec)
-            var inputs = [String: [String]]()
-            inputs["in"] = bits
-
-            // Multiplier example
-            // var inputs = [String: [String]]()
-            // let a = 3
-            // let b = 5
-            // inputs["a"] = [String(a)]
-            // inputs["b"] = [String(b)]
-
-            // Record start time
-            let start = CFAbsoluteTimeGetCurrent()
-
-            // Generate Proof
-            let generateProofResult = try moproCircom.generateProof(circuitInputs: inputs)
-            assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
-
-            // Record end time and compute duration
-            let end = CFAbsoluteTimeGetCurrent()
-            let timeTaken = end - start
-
-            // Store the generated proof and public inputs for later verification
-            generatedProof = generateProofResult.proof
-            publicInputs = generateProofResult.inputs
-
-            textView.text += "Proof generation took \(timeTaken) seconds.\n"
-            verifyButton.isEnabled = true // Enable the Verify button once proof has been generated
-        } catch let error as MoproError {
-            print("MoproError: \(error)")
-        } catch {
-            print("Unexpected error: \(error)")
-        }
+  @objc func runProveAction() {
+    // Logic for prove
+    guard proveButton.isEnabled else {
+      print("Setup is not completed yet.")
+      return
     }
+    do {
+      // Prepare inputs
+      let inputVec: [UInt8] = [
+        116, 101, 115, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+      ]
+      let bits = bytesToBits(bytes: inputVec)
+      var inputs = [String: [String]]()
+      inputs["in"] = bits
 
-    @objc func runVerifyAction() {
-        // Logic for verify
-        guard let proof = generatedProof,
-                let publicInputs = publicInputs else {
-            print("Setup is not completed or proof has not been generated yet.")
-            return
-        }
-        do {
-            // Verify Proof
-            let isValid = try moproCircom.verifyProof(proof: proof, publicInput: publicInputs)
-            assert(isValid, "Proof verification should succeed")
+      // Multiplier example
+      // var inputs = [String: [String]]()
+      // let a = 3
+      // let b = 5
+      // inputs["a"] = [String(a)]
+      // inputs["b"] = [String(b)]
 
-            textView.text += "Proof verification succeeded.\n"
-        } catch let error as MoproError {
-            print("MoproError: \(error)")
-        } catch {
-            print("Unexpected error: \(error)")
-        }
+      // Record start time
+      let start = CFAbsoluteTimeGetCurrent()
+
+      // Generate Proof
+      let generateProofResult = try moproCircom.generateProof(circuitInputs: inputs)
+      assert(!generateProofResult.proof.isEmpty, "Proof should not be empty")
+
+      // Record end time and compute duration
+      let end = CFAbsoluteTimeGetCurrent()
+      let timeTaken = end - start
+
+      // Store the generated proof and public inputs for later verification
+      generatedProof = generateProofResult.proof
+      publicInputs = generateProofResult.inputs
+
+      textView.text += "Proof generation took \(timeTaken) seconds.\n"
+      verifyButton.isEnabled = true  // Enable the Verify button once proof has been generated
+    } catch let error as MoproError {
+      print("MoproError: \(error)")
+    } catch {
+      print("Unexpected error: \(error)")
     }
+  }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+  @objc func runVerifyAction() {
+    // Logic for verify
+    guard let proof = generatedProof,
+      let publicInputs = publicInputs
+    else {
+      print("Setup is not completed or proof has not been generated yet.")
+      return
     }
+    do {
+      // Verify Proof
+      let isValid = try moproCircom.verifyProof(proof: proof, publicInput: publicInputs)
+      assert(isValid, "Proof verification should succeed")
+
+      textView.text += "Proof verification succeeded.\n"
+    } catch let error as MoproError {
+      print("MoproError: \(error)")
+    } catch {
+      print("Unexpected error: \(error)")
+    }
+  }
+
+  override func didReceiveMemoryWarning() {
+    super.didReceiveMemoryWarning()
+    // Dispose of any resources that can be recreated.
+  }
 }
 
 func bytesToBits(bytes: [UInt8]) -> [String] {
-    var bits = [String]()
-    for byte in bytes {
-        for j in 0..<8 {
-            let bit = (byte >> j) & 1
-            bits.append(String(bit))
-        }
+  var bits = [String]()
+  for byte in bytes {
+    for j in 0..<8 {
+      let bit = (byte >> j) & 1
+      bits.append(String(bit))
     }
-    return bits
+  }
+  return bits
 }

--- a/mopro-ios/MoproKit/Example/Tests/CircomTests.swift
+++ b/mopro-ios/MoproKit/Example/Tests/CircomTests.swift
@@ -6,9 +6,9 @@ final class CircomTests: XCTestCase {
     let moproCircom = MoproKit.MoproCircom()
     
     func testMultiplier() {
+        let arkzkeyPath = Bundle.main.path(forResource: "multiplier2_final", ofType: "arkzkey")!
         let wasmPath = Bundle.main.path(forResource: "multiplier2", ofType: "wasm")!
-        let r1csPath = Bundle.main.path(forResource: "multiplier2", ofType: "r1cs")!
-        XCTAssertNoThrow(try moproCircom.setup(wasmPath: wasmPath, r1csPath: r1csPath), "Mopro circom setup failed")
+        XCTAssertNoThrow(try moproCircom.initialize(arkzkeyPath: arkzkeyPath, wasmPath: wasmPath), "Mopro circom setup failed")
         
         do {
             var inputs = [String: [String]]()
@@ -35,9 +35,9 @@ final class CircomTests: XCTestCase {
     }
     
     func testKeccak256() {
+        let arkzkeyPath = Bundle.main.path(forResource: "keccak256_256_test_final", ofType: "arkzkey")!
         let wasmPath = Bundle.main.path(forResource: "keccak256_256_test", ofType: "wasm")!
-        let r1csPath = Bundle.main.path(forResource: "keccak256_256_test", ofType: "r1cs")!
-        XCTAssertNoThrow(try moproCircom.setup(wasmPath: wasmPath, r1csPath: r1csPath), "Mopro circom setup failed")
+        XCTAssertNoThrow(try moproCircom.initialize(arkzkeyPath: arkzkeyPath, wasmPath: wasmPath), "Mopro circom setup failed")
         
         do {
             // Prepare inputs

--- a/mopro-ios/MoproKit/Include/moproFFI.h
+++ b/mopro-ios/MoproKit/Include/moproFFI.h
@@ -70,7 +70,7 @@ void*_Nonnull uniffi_mopro_ffi_fn_constructor_moprocircom_new(RustCallStatus *_N
 );
 RustBuffer uniffi_mopro_ffi_fn_method_moprocircom_generate_proof(void*_Nonnull ptr, RustBuffer circuit_inputs, RustCallStatus *_Nonnull out_status
 );
-RustBuffer uniffi_mopro_ffi_fn_method_moprocircom_setup(void*_Nonnull ptr, RustBuffer wasm_path, RustBuffer r1cs_path, RustCallStatus *_Nonnull out_status
+void uniffi_mopro_ffi_fn_method_moprocircom_initialize(void*_Nonnull ptr, RustBuffer arkzkey_path, RustBuffer wasm_path, RustCallStatus *_Nonnull out_status
 );
 int8_t uniffi_mopro_ffi_fn_method_moprocircom_verify_proof(void*_Nonnull ptr, RustBuffer proof, RustBuffer public_input, RustCallStatus *_Nonnull out_status
 );
@@ -238,7 +238,7 @@ uint16_t uniffi_mopro_ffi_checksum_func_verify_proof2(void
 uint16_t uniffi_mopro_ffi_checksum_method_moprocircom_generate_proof(void
     
 );
-uint16_t uniffi_mopro_ffi_checksum_method_moprocircom_setup(void
+uint16_t uniffi_mopro_ffi_checksum_method_moprocircom_initialize(void
     
 );
 uint16_t uniffi_mopro_ffi_checksum_method_moprocircom_verify_proof(void


### PR DESCRIPTION
Implementation for https://github.com/oskarth/mopro/issues/65

- update `MoproCircom` to initialize with arkzkey and wasm
- download arkzkey and wasm in `KeccakSetupViewController`
- result
   **KeccakSetupViewController (this PR)**
   ```
   Download wasm took: 0.6701240539550781s
   Download ark key took: 1.6424980163574219s
   
   Initializing arkzkey and wasm took 8.671825051307678s

   Proof generation took 1.5237200260162354 seconds.

   Proof verification succeeded.
   ```
   **KeccakZkeyViewController (generateProof2)**
   ```
   Initializing arkzkey took 8.844295024871826 seconds.

   Proof generation took 1.4890559911727905 seconds.
   ```
- result in iPhone device (iPhone 12 mini)
   (This PR)
   ![IMG_4734](https://github.com/oskarth/mopro/assets/17507085/8f7b1869-231a-4794-a827-7d2e6d59d1ad)
   
   (generateProof2)
   ![IMG_4735](https://github.com/oskarth/mopro/assets/17507085/18cef70d-234a-4f2c-9190-50afa232adaf)
