### PR TITLE
Fix CI, cache compiled `toml` and `uniffi-bindgen`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,12 +21,35 @@ jobs:
   test-ios:
     runs-on: macos-latest
     steps:
-    # TODO: We should be able to cache this
+      - uses: actions/checkout@v3
+      - name: Cache toml
+        uses: actions/cache@v4
+        id: toml-macos-restore
+        with:
+          path: /Users/runner/.cargo/bin/toml
+          key: ${{ runner.os }}-toml-0.2.3 # version of toml-cli 0.2.3
+      - name: Cache circom
+        uses: actions/cache@v4
+        id: circom-macos-restore
+        with:
+            path: /Users/runner/.cargo/bin/circom
+            key: ${{ runner.os }}-circom-2.1.8 # version of circom 2.1.8
       - name: Install circom
+        if: steps.circom-macos-restore.outputs.cache-hit != 'true'
         run: |
           sudo wget -O /Users/runner/.cargo/bin/circom https://github.com/iden3/circom/releases/download/v2.1.8/circom-macos-amd64
           sudo chmod +x /Users/runner/.cargo/bin/circom
-      - uses: actions/checkout@v3
+      - name: Get uniffi-version
+        if: steps.toml-macos-restore.outputs.cache-hit == 'true'
+        id: extract-version
+        run: UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)
+      - name: Cache uniffi-bindgen
+        uses: actions/cache@v4
+        if: steps.toml-macos-restore.outputs.cache-hit == 'true'
+        id: uniffi-bindgen-macos-restore
+        with:
+            path: /Users/runner/.cargo/bin/uniffi-bindgen
+            key: ${{ runner.os }}-uniffi-bindgen-${{ steps.extract-version.outputs.UNIFFI_VERSION }}
       - name: Prepare CI for iOS
         run: ./scripts/prepare_ci.sh
       - name: Build for iOS
@@ -35,15 +58,49 @@ jobs:
         run: |
           cd mopro-ios/MoproKit/Example
           xcodebuild test -scheme MoproKit-Example -workspace MoproKit.xcworkspace -destination "platform=iOS Simulator,OS=16.2,name=iPhone 14 Pro"
+      - name: Get uniffi-version
+        if: steps.uniffi-bindgen-macos-restore.outputs.cache-hit != 'true'
+        id: post-extract-version
+        run: UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)
+      - name: Save uniffi-bindgen cache
+        if: steps.uniffi-bindgen-macos-restore.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+            path: /Users/runner/.cargo/bin/uniffi-bindgen
+            key: ${{ runner.os }}-uniffi-bindgen-${{ steps.post-extract-version.outputs.UNIFFI_VERSION }}
 
   test-android:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - name: Restore toml
+        uses: actions/cache@v4
+        id: toml-linux-restore
+        with:
+          path: /home/runner/.cargo/bin/toml
+          key: ${{ runner.os }}-toml-0.2.3 # version of toml-cli 0.2.3
+      - name: Restore circom
+        uses: actions/cache@v4
+        id: circom-linux-restore
+        with:
+          path: /usr/bin/circom
+          key: ${{ runner.os }}-circom-2.1.8
       - name: Install circom
+        if: steps.circom-linux-restore.outputs.cache-hit != 'true'
         run: |
           sudo wget -O /usr/bin/circom https://github.com/iden3/circom/releases/download/v2.1.8/circom-linux-amd64
           sudo chmod +x /usr/bin/circom
-      - uses: actions/checkout@v3
+      - name: Get uniffi-version
+        id: extract-version
+        if: steps.toml-linux-restore.outputs.cache-hit == 'true'
+        run: UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)
+      - name: Restore uniffi-bindgen
+        uses: actions/cache@v4
+        if: steps.toml-linux-restore.outputs.cache-hit == 'true'
+        id: uniffi-bindgen-linux-restore
+        with:
+            path: /home/runner/.cargo/bin/uniffi-bindgen
+            key: ${{ runner.os }}-uniffi-bindgen-${{ steps.extract-version.outputs.UNIFFI_VERSION }}
       - name: Prepare CI for Core and FFI
         run: ./scripts/prepare_ci.sh
       - name: Build for Android
@@ -56,3 +113,13 @@ jobs:
           cd mopro-ffi/
           curl -L https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar -o target/jna-5.13.0.jar
           CLASSPATH=target/jna-5.13.0.jar cargo test -- --nocapture
+      - name: Get uniffi-version
+        if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
+        id: post-extract-version
+        run: UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)
+      - name: Save uniffi-bindgen
+        uses: actions/cache@v4
+        if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
+        with:
+            path: /home/runner/.cargo/bin/uniffi-bindgen
+            key: ${{ runner.os }}-uniffi-bindgen-${{ steps.post-extract-version.outputs.UNIFFI_VERSION }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Prepare CI for Core and FFI
         run: ./scripts/prepare_ci.sh
       - name: Build for Android
-        run: ./scripts/build_android.sh config-example-android.toml
+        run: ./scripts/build_android.sh config-android-ci.toml
       - name: Run core tests
         run: cd mopro-core && cargo test -- --nocapture
       - name: Run FFI tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,14 +28,7 @@ jobs:
         with:
           path: /Users/runner/.cargo/bin/toml
           key: ${{ runner.os }}-toml-0.2.3 # version of toml-cli 0.2.3
-      - name: Cache circom
-        uses: actions/cache@v4
-        id: circom-macos-restore
-        with:
-            path: /Users/runner/.cargo/bin/circom
-            key: ${{ runner.os }}-circom-2.1.8 # version of circom 2.1.8
       - name: Install circom
-        if: steps.circom-macos-restore.outputs.cache-hit != 'true'
         run: |
           sudo wget -O /Users/runner/.cargo/bin/circom https://github.com/iden3/circom/releases/download/v2.1.8/circom-macos-amd64
           sudo chmod +x /Users/runner/.cargo/bin/circom
@@ -77,14 +70,7 @@ jobs:
         with:
           path: /home/runner/.cargo/bin/toml
           key: ${{ runner.os }}-toml-0.2.3 # version of toml-cli 0.2.3
-      - name: Restore circom
-        uses: actions/cache@v4
-        id: circom-linux-restore
-        with:
-          path: /usr/bin/circom
-          key: ${{ runner.os }}-circom-2.1.8
       - name: Install circom
-        if: steps.circom-linux-restore.outputs.cache-hit != 'true'
         run: |
           sudo wget -O /usr/bin/circom https://github.com/iden3/circom/releases/download/v2.1.8/circom-linux-amd64
           sudo chmod +x /usr/bin/circom

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,8 +111,8 @@ jobs:
       # TODO: Fix this custom jar thing
         run: |
           cd mopro-ffi/
-          curl -L https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar -o target/jna-5.13.0.jar
-          CLASSPATH=target/jna-5.13.0.jar cargo test -- --nocapture
+          curl -L https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar -o jna-5.13.0.jar
+          CLASSPATH=jna-5.13.0.jar cargo test -- --nocapture
       - name: Get uniffi-version
         if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
         id: post-extract-version

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,15 +41,14 @@ jobs:
           sudo chmod +x /Users/runner/.cargo/bin/circom
       - name: Get uniffi-version
         if: steps.toml-macos-restore.outputs.cache-hit == 'true'
-        id: extract-version
-        run: UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)
+        run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
       - name: Cache uniffi-bindgen
         uses: actions/cache@v4
         if: steps.toml-macos-restore.outputs.cache-hit == 'true'
         id: uniffi-bindgen-macos-restore
         with:
             path: /Users/runner/.cargo/bin/uniffi-bindgen
-            key: ${{ runner.os }}-uniffi-bindgen-${{ steps.extract-version.outputs.UNIFFI_VERSION }}
+            key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}
       - name: Prepare CI for iOS
         run: ./scripts/prepare_ci.sh
       - name: Build for iOS
@@ -60,14 +59,13 @@ jobs:
           xcodebuild test -scheme MoproKit-Example -workspace MoproKit.xcworkspace -destination "platform=iOS Simulator,OS=16.2,name=iPhone 14 Pro"
       - name: Get uniffi-version
         if: steps.uniffi-bindgen-macos-restore.outputs.cache-hit != 'true'
-        id: post-extract-version
-        run: UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)
+        run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
       - name: Save uniffi-bindgen cache
         if: steps.uniffi-bindgen-macos-restore.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
             path: /Users/runner/.cargo/bin/uniffi-bindgen
-            key: ${{ runner.os }}-uniffi-bindgen-${{ steps.post-extract-version.outputs.UNIFFI_VERSION }}
+            key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}
 
   test-android:
     runs-on: ubuntu-latest
@@ -91,16 +89,15 @@ jobs:
           sudo wget -O /usr/bin/circom https://github.com/iden3/circom/releases/download/v2.1.8/circom-linux-amd64
           sudo chmod +x /usr/bin/circom
       - name: Get uniffi-version
-        id: extract-version
         if: steps.toml-linux-restore.outputs.cache-hit == 'true'
-        run: UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)
+        run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
       - name: Restore uniffi-bindgen
         uses: actions/cache@v4
         if: steps.toml-linux-restore.outputs.cache-hit == 'true'
         id: uniffi-bindgen-linux-restore
         with:
             path: /home/runner/.cargo/bin/uniffi-bindgen
-            key: ${{ runner.os }}-uniffi-bindgen-${{ steps.extract-version.outputs.UNIFFI_VERSION }}
+            key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}
       - name: Prepare CI for Core and FFI
         run: ./scripts/prepare_ci.sh
       - name: Build for Android
@@ -115,11 +112,10 @@ jobs:
           CLASSPATH=jna-5.13.0.jar cargo test -- --nocapture
       - name: Get uniffi-version
         if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
-        id: post-extract-version
-        run: UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)
+        run: echo "UNIFFI_VERSION=$(toml get mopro-ffi/Cargo.toml dependencies.uniffi.version -r)" >> $GITHUB_ENV
       - name: Save uniffi-bindgen
         uses: actions/cache@v4
         if: steps.uniffi-bindgen-linux-restore.outputs.cache-hit != 'true'
         with:
             path: /home/runner/.cargo/bin/uniffi-bindgen
-            key: ${{ runner.os }}-uniffi-bindgen-${{ steps.post-extract-version.outputs.UNIFFI_VERSION }}
+            key: ${{ runner.os }}-uniffi-bindgen-${{ env.UNIFFI_VERSION }}

--- a/config-android-ci.toml
+++ b/config-android-ci.toml
@@ -1,0 +1,22 @@
+# config-android-ci.toml
+
+# Android specific configuration
+
+[build]
+# For iOS device_type can be x86_64, simulator, device
+# For Android device_type can be x86_64, arm, arm64
+device_type = "x86_64" # Options: x86_64, simulator, device, arm, arm64
+
+# debug is for Rust library to be in debug mode and release for release mode
+# We recommend release mode by default for performance
+build_mode = "release" # Options: debug, release
+
+[circuit]
+dir = "examples/circom/keccak256" # Directory of the circuit
+name = "keccak256_256_test"       # Name of the circuit
+
+[dylib]
+# NOTE: Dylib support is experimental and requires some fiddling in iOS
+# See https://github.com/oskarth/mopro/pull/37 and https://github.com/oskarth/mopro/pull/38
+use_dylib = false        # Options: true, false
+name = "keccak256.dylib" # Name of the dylib file, only used if use_dylib is true

--- a/config-example-android.toml
+++ b/config-example-android.toml
@@ -9,7 +9,7 @@ device_type = "arm64" # Options: x86_64, simulator, device, arm, arm64
 
 # debug is for Rust library to be in debug mode and release for release mode
 # We recommend release mode by default for performance
-build_mode = "debug" # Options: debug, release
+build_mode = "release" # Options: debug, release
 
 [circuit]
 dir = "examples/circom/keccak256" # Directory of the circuit

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -77,12 +77,15 @@ PROJECT_DIR=$(pwd)
 
 cd ${PROJECT_DIR}/mopro-ffi
 
+print_action "[android] Install cargo-ndk"
+cargo install cargo-ndk
+
 # Print appropriate message based on device type
 print_action "Using $ARCHITECTURE libmopro_ffi.a ($LIB_DIR) static library..."
 print_warning "This only works on $FOLDER devices!"
 
 print_action "[android] Build target in $BUILD_MODE mode"
-cargo build --lib ${COMMAND} --target ${ARCHITECTURE}
+cargo ndk -t ${ARCHITECTURE} build --lib ${COMMAND} 
 
 print_action "[android] Copy files in mopro-android/Example/jniLibs/"
 for binary in target/*/*/libmopro_ffi.so; do file $binary; done

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -88,10 +88,10 @@ print_action "[android] Build target in $BUILD_MODE mode"
 cargo ndk -t ${ARCHITECTURE} build --lib ${COMMAND} 
 
 print_action "[android] Copy files in mopro-android/Example/jniLibs/"
-for binary in target/*/*/libmopro_ffi.so; do file $binary; done
+for binary in ${PROJECT_DIR}/target/*/*/libmopro_ffi.so; do file $binary; done
 
 mkdir -p jniLibs/${FOLDER}/ && \
-cp target/${ARCHITECTURE}/${LIB_DIR}/libmopro_ffi.so jniLibs/${FOLDER}/libuniffi_mopro.so
+cp ${PROJECT_DIR}/target/${ARCHITECTURE}/${LIB_DIR}/libmopro_ffi.so jniLibs/${FOLDER}/libuniffi_mopro.so
 
 print_action "[android] Generating Kotlin bindings in $BUILD_MODE mode..."
 cargo run --features=uniffi/cli ${COMMAND} \


### PR DESCRIPTION
- fix #52 
- cache `toml`, `uniffi-bindgen`
  - speed up ~10m with cache