### PR TITLE
fix: fix dylib file path in build scripts

### DIFF
--- a/mopro-core/build.rs
+++ b/mopro-core/build.rs
@@ -134,7 +134,7 @@ fn build_dylib(config: &Config) -> Result<()> {
 
             // Copy dylib to a more predictable path
             fs::create_dir_all(&final_dir_path)?;
-            let final_dylib_path = final_dir_path.join(format!("{}.dylib", dylib_name));
+            let final_dylib_path = final_dir_path.join(format!("{}", dylib_name));
             fs::copy(&dylib_file_path, &final_dylib_path)?;
 
             println!(

--- a/scripts/cli/build_ios.sh
+++ b/scripts/cli/build_ios.sh
@@ -143,8 +143,8 @@ build_mopro_ffi_with_dylib_circuit() {
     # fi
 
     print_action "Copying dylib circuit to target directory..."
-    cp "${MOPRO_ROOT}/mopro-core/target/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}.dylib" \
-        "${TARGET_DIR}/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}.dylib"
+    cp "${MOPRO_ROOT}/mopro-core/target/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}" \
+        "${TARGET_DIR}/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}"
 }
 
 generate_swift_bindings() {
@@ -206,7 +206,7 @@ create_xcframework_circuit() {
 
     print_action "Creating XCFramework for CircuitBindings dylib... (${ARCHITECTURE})"
     xcodebuild -create-xcframework \
-        -library "${TARGET_DIR}/${ARCHITECTURE}/release/${DYLIB_NAME}.dylib" \
+        -library "${TARGET_DIR}/${ARCHITECTURE}/release/${DYLIB_NAME}" \
         -output "$CIRCUIT_XCFRAMEWORK_PATH"
     if [ $? -ne 0 ]; then
         echo -e "${RED}Failed to create CircuitBindings XCFramework.${DEFAULT}"

--- a/scripts/update_bindings.sh
+++ b/scripts/update_bindings.sh
@@ -152,7 +152,7 @@ cp ${TARGET_DIR}/libmopro_ffi.a ${MOPROKIT_DIR}/Libs/
 # Dylib assets
 if [[ "$USE_DYLIB" == true ]]; then
     print_action "Copying dynamic library asset (${DYLIB_NAME})..."
-    cp "${PROJECT_DIR}/target/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}" "${TARGET_DIR}/"
+    cp "${PROJECT_DIR}/mopro-core/target/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}" "${TARGET_DIR}/"
     cp "${TARGET_DIR}/${DYLIB_NAME}" "${MOPROKIT_DIR}/Libs/"
     # Fix dynamic lib install paths
     # NOTE: Xcode might already do this for us; verify this


### PR DESCRIPTION
- fix copying `.dylib` from `mopro-core/target`
- fix duplicated `.dylib` in script and `config.toml`