### PR TITLE
fix: fix npm_install script if there is no package.json

### DIFF
--- a/scripts/cli/prepare.sh
+++ b/scripts/cli/prepare.sh
@@ -82,7 +82,7 @@ read_toml() {
 
 # Install npm dependencies
 npm_install() {
-    if [[ ! -d "${CIRCUIT_DIR}/node_modules" ]]; then
+    if [[ -f "${CIRCUIT_DIR}/package.json" && ! -d "${CIRCUIT_DIR}/node_modules" ]]; then
         echo "Installing npm dependencies for $CIRCUIT_DIR..."
         (cd $CIRCUIT_DIR && npm install)
     fi


### PR DESCRIPTION
- for multiplier.circom, there is no `package.json` so it throws error.
- In `prepare.sh` we can check if there is a `package.json` file then execute `npm install`