### PR TITLE
fix: codesign dylib in mopro-cli

### DIFF
--- a/scripts/cli/build_ios.sh
+++ b/scripts/cli/build_ios.sh
@@ -145,6 +145,15 @@ build_mopro_ffi_with_dylib_circuit() {
     print_action "Copying dylib circuit to target directory..."
     cp "${MOPRO_ROOT}/mopro-core/target/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}" \
         "${TARGET_DIR}/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}"
+
+    if [ -z "${APPLE_SIGNING_IDENTITY+x}" ]; then
+        echo "${RED}APPLE_SIGNING_IDENTITY is not set.${DEFAULT}"
+        echo "${RED}Please set APPLE_SIGNING_IDENTITY to one of these identities.${DEFAULT}"
+        echo "${RED}`security find-identity -v -p codesigning`${DEFAULT}"
+        exit 1
+    fi
+    install_name_tool -id "@rpath/${DYLIB_NAME}" "${TARGET_DIR}/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}"
+    codesign -f -s "${APPLE_SIGNING_IDENTITY}" "${TARGET_DIR}/${ARCHITECTURE}/${LIB_DIR}/${DYLIB_NAME}"
 }
 
 generate_swift_bindings() {


### PR DESCRIPTION
- use `codesign` in `mopro build --platforms ios` if using dylib
- It will list all apple ids
<img width="855" alt="" src="https://github.com/oskarth/mopro/assets/17507085/1e6365cd-a189-4a10-adb5-6ed470d92646">
